### PR TITLE
Faster updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Heavily inspired by [Sublime Gremlins](https://packagecontrol.io/packages/Gremli
   - Non-breaking spaces
   - Left and right double quotation marks
 - Move the cursor over the character to have a hint of the potential issue
-- A gremlin icon is show in the gutter for every line that contains at least one of these characters
+- A gremlin icon is shown in the gutter for every line that contains at least one of these characters
 
 ![A screenshot of Gremlins in action](images/screenshot.png)
 
@@ -24,28 +24,25 @@ Heavily inspired by [Sublime Gremlins](https://packagecontrol.io/packages/Gremli
 The list of supported characters is an array at the begining of the extension source code:
 
 ```javascript
-const gremlins = [
-  {
-    char: '200b',
-    regex: /\u200b+/g,
-    width: 0,
-    message: 'zero width space',
+const gremlinsConfig = {
+  '200b': {
+    zeroWidth: true,
+    description: 'zero width space',
   },
-  {
-    char: '00a0',
-    regex: /\u00a0+/g,
-    width: 1,
-    message: 'non breaking space',
+  '00a0': {
+    description: 'non breaking space',
   },
-  {
-    char: '201d',
-    regex: /\u201d+/g,
-    width: 1,
-    message: 'right double quotation mark',
+  '201c': {
+    description: 'left double quotation mark',
     backgroundColor: 'rgba(255,127,80,.5)',
     overviewRulerColor: 'rgba(255,127,80,1)',
   },
-]
+  '201d': {
+    description: 'right double quotation mark',
+    backgroundColor: 'rgba(255,127,80,.5)',
+    overviewRulerColor: 'rgba(255,127,80,1)',
+  },
+}
 ```
 
 Please help enhance the extension by suggesting new characters, through Pull Requests or Issues.

--- a/extension.js
+++ b/extension.js
@@ -1,33 +1,26 @@
 var vscode = require('vscode')
 
-const gremlinsConfig = [
-  {
-    char: '200b',
-    width: 0,
-    message: 'zero width space',
+const gremlinsConfig = {
+  '200b': {
+    zeroWidth: true,
+    description: 'zero width space',
   },
-  {
-    char: '00a0',
-    width: 1,
-    message: 'non breaking space',
+  '00a0': {
+    description: 'non breaking space',
   },
-  {
-    char: '201c',
-    width: 1,
-    message: 'left double quotation mark',
+  '201c': {
+    description: 'left double quotation mark',
     backgroundColor: 'rgba(255,127,80,.5)',
     overviewRulerColor: 'rgba(255,127,80,1)',
   },
-  {
-    char: '201d',
-    width: 1,
-    message: 'right double quotation mark',
+  '201d': {
+    description: 'right double quotation mark',
     backgroundColor: 'rgba(255,127,80,.5)',
     overviewRulerColor: 'rgba(255,127,80,1)',
   },
-]
+}
 
-function activate(context) {
+function gremlinsFromConfig(context) {
   const lightIcon = {
     gutterIconPath: context.asAbsolutePath('images/gremlins-light.svg'),
     gutterIconSize: 'contain',
@@ -37,96 +30,124 @@ function activate(context) {
     gutterIconSize: 'contain',
   }
 
+  const gremlins = {}
+  for (const [hexCodePoint, config] of Object.entries(gremlinsConfig)) {
+    let decorationType = {
+      light: lightIcon,
+      dark: darkIcon,
+      overviewRulerColor: config.overviewRulerColor || 'darkred',
+      overviewRulerLane: vscode.OverviewRulerLane.Right,
+    }
+
+    if (config.zeroWidth) {
+      decorationType.borderWidth = '1px'
+      decorationType.borderStyle = 'solid'
+      decorationType.borderColor = config.borderColor || 'darkred'
+    } else {
+      decorationType.backgroundColor =
+        config.backgroundColor || 'rgba(255,128,128,.5)'
+    }
+
+    gremlins[charFromHex(hexCodePoint)] = Object.assign({}, config, {
+      hexCodePoint,
+      decorationType: vscode.window.createTextEditorDecorationType(
+        decorationType,
+      ),
+    })
+  }
+
+  return gremlins
+}
+
+function charFromHex(hexCodePoint) {
+  return String.fromCodePoint(`0x${hexCodePoint}`)
+}
+
+function updateDecorations(activeTextEditor, gremlins, regexpWithAllChars) {
+  if (!activeTextEditor) {
+    return
+  }
+
+  const doc = activeTextEditor.document
+
+  const decorationOption = {}
+  for (const char in gremlins) {
+    decorationOption[char] = []
+  }
+
+  for (let lineNum = 0; lineNum < doc.lineCount; lineNum++) {
+    let lineText = doc.lineAt(lineNum)
+    let line = lineText.text
+
+    let match
+    while ((match = regexpWithAllChars.exec(line))) {
+      const matchedCharacter = match[0][0]
+
+      const gremlin = gremlins[matchedCharacter]
+      let startPos = new vscode.Position(lineNum, match.index)
+      let endPos = new vscode.Position(lineNum, match.index + match[0].length)
+      const decoration = {
+        range: new vscode.Range(startPos, endPos),
+        hoverMessage:
+          match[0].length +
+          ' ' +
+          gremlin.description +
+          (match[0].length > 1 ? 's' : '') +
+          ' (unicode U+' +
+          gremlin.hexCodePoint +
+          ') here',
+      }
+
+      decorationOption[matchedCharacter].push(decoration)
+    }
+  }
+
+  for (const [char, gremlin] of Object.entries(gremlins)) {
+    activeTextEditor.setDecorations(
+      gremlin.decorationType,
+      decorationOption[char],
+    )
+  }
+}
+
+function activate(context) {
+  const gremlins = gremlinsFromConfig(context)
+
+  const regexpWithAllChars = new RegExp(
+    Object.keys(gremlinsConfig)
+      .map(hexCodePoint => charFromHex(hexCodePoint) + '+')
+      .join('|'),
+    'g',
+  )
+
   vscode.window.onDidChangeActiveTextEditor(
-    editor => updateDecorations(editor),
+    editor => updateDecorations(editor, gremlins, regexpWithAllChars),
     null,
     context.subscriptions,
   )
 
   vscode.window.onDidChangeTextEditorSelection(
-    event => updateDecorations(event.textEditor),
+    event => updateDecorations(event.textEditor, gremlins, regexpWithAllChars),
     null,
     context.subscriptions,
   )
 
   vscode.workspace.onDidChangeTextDocument(
-    event => updateDecorations(vscode.window.activeTextEditor),
+    event =>
+      updateDecorations(
+        vscode.window.activeTextEditor,
+        gremlins,
+        regexpWithAllChars,
+      ),
     null,
     context.subscriptions,
   )
 
-  const gremlins = gremlinsConfig.map(gremlin => {
-    const regex = new RegExp(`\\u${gremlin.char}+`, 'g')
-    let decorationType
-    switch (gremlin.width) {
-      case 0:
-        decorationType = vscode.window.createTextEditorDecorationType({
-          borderWidth: '1px',
-          borderStyle: 'solid',
-          borderColor: gremlin.borderColor || 'darkred',
-          overviewRulerColor: gremlin.overviewRulerColor || 'darkred',
-          overviewRulerLane: vscode.OverviewRulerLane.Right,
-          light: lightIcon,
-          dark: darkIcon,
-        })
-        break
-      case 1:
-        decorationType = vscode.window.createTextEditorDecorationType({
-          backgroundColor: gremlin.backgroundColor || 'rgba(255,128,128,.5)',
-          overviewRulerColor: gremlin.overviewRulerColor || 'darkred',
-          overviewRulerLane: vscode.OverviewRulerLane.Right,
-          light: lightIcon,
-          dark: darkIcon,
-        })
-        break
-      default:
-        break
-    }
-
-    return Object.assign({}, gremlin, { decorationType, regex })
-  })
-
-  function updateDecorations(activeTextEditor) {
-    if (!activeTextEditor) {
-      return
-    }
-
-    const doc = activeTextEditor.document
-
-    for (const gremlin of gremlins) {
-      const decorationOption = []
-
-      for (let lineNum = 0; lineNum < doc.lineCount; lineNum++) {
-        let lineText = doc.lineAt(lineNum)
-        let line = lineText.text
-
-        let match
-        while ((match = gremlin.regex.exec(line))) {
-          let startPos = new vscode.Position(lineNum, match.index)
-          let endPos = new vscode.Position(
-            lineNum,
-            match.index + match[0].length,
-          )
-          const decoration = {
-            range: new vscode.Range(startPos, endPos),
-            hoverMessage:
-              match[0].length +
-              ' ' +
-              gremlin.message +
-              (match[0].length > 1 ? 's' : '') +
-              ' (unicode U+' +
-              gremlin.char +
-              ') here',
-          }
-          decorationOption.push(decoration)
-        }
-      }
-
-      activeTextEditor.setDecorations(gremlin.decorationType, decorationOption)
-    }
-  }
-
-  updateDecorations(vscode.window.activeTextEditor)
+  updateDecorations(
+    vscode.window.activeTextEditor,
+    gremlins,
+    regexpWithAllChars,
+  )
 }
 exports.activate = activate
 


### PR DESCRIPTION
Instead of looping the document n times (n being the number of gremlins), we create a regexp that matches every gremlin and only loop the document once.
With 4 gremlins, that makes it about 3 times faster [1]. As we add more gremlins, it should not go slower with this algorithm.

I've also done some other cosmetic changes:
- Change some variable names
- Extract functions

[1]: ~40ms instead of ~160ms on my laptop for the HTML of https://html.spec.whatwg.org