### PR TITLE
Add zero width non-joiner to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This [Visual Studio Code](https://code.visualstudio.com/) extension reveals some
 ## Features
 
 - When there is a zero-width space in the code, the extension shows a red bar
+- When there is a zero-width non-joiner in the code, the extension shows a red bar
 - A few characters that can be harmful have a light red or orange background
   - Non-breaking spaces
   - Left and right double quotation marks
@@ -26,6 +27,10 @@ const gremlinsConfig = {
   '200b': {
     zeroWidth: true,
     description: 'zero width space',
+  },
+  '200c': {
+    zeroWidth: true,
+    description: 'zero width non-joiner',
   },
   '00a0': {
     description: 'non breaking space',

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -22,6 +22,24 @@ Array [
   ],
   Array [
     Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
+  Array [
+    Object {
       "backgroundColor": "rgba(255,128,128,.5)",
       "dark": Object {
         "gutterIconPath": "images/gremlins-dark.svg",
@@ -91,6 +109,24 @@ Array [
 
 exports[`shows left double quotation mark 1`] = `
 Array [
+  Array [
+    Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
   Array [
     Object {
       "borderColor": "darkred",
@@ -228,6 +264,38 @@ Array [
   ],
   Array [
     Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [
+      Object {
+        "hoverMessage": "3 zero width non-joiners (unicode U+200c) here",
+        "range": Object {
+          "left": Object {
+            "char": 24,
+            "line": 2,
+          },
+          "right": Object {
+            "char": 27,
+            "line": 2,
+          },
+        },
+      },
+    ],
+  ],
+  Array [
+    Object {
       "backgroundColor": "rgba(255,128,128,.5)",
       "dark": Object {
         "gutterIconPath": "images/gremlins-dark.svg",
@@ -246,11 +314,11 @@ Array [
         "range": Object {
           "left": Object {
             "char": 21,
-            "line": 2,
+            "line": 3,
           },
           "right": Object {
             "char": 24,
-            "line": 2,
+            "line": 3,
           },
         },
       },
@@ -276,11 +344,11 @@ Array [
         "range": Object {
           "left": Object {
             "char": 29,
-            "line": 3,
+            "line": 4,
           },
           "right": Object {
             "char": 32,
-            "line": 3,
+            "line": 4,
           },
         },
       },
@@ -306,11 +374,11 @@ Array [
         "range": Object {
           "left": Object {
             "char": 30,
-            "line": 4,
+            "line": 5,
           },
           "right": Object {
             "char": 33,
-            "line": 4,
+            "line": 5,
           },
         },
       },
@@ -339,6 +407,24 @@ Array [
 
 exports[`shows non breaking space 1`] = `
 Array [
+  Array [
+    Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
   Array [
     Object {
       "borderColor": "darkred",
@@ -462,6 +548,24 @@ Array [
   ],
   Array [
     Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
+  Array [
+    Object {
       "backgroundColor": "rgba(255,128,128,.5)",
       "dark": Object {
         "gutterIconPath": "images/gremlins-dark.svg",
@@ -565,6 +669,24 @@ Array [
   ],
   Array [
     Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
+  Array [
+    Object {
       "backgroundColor": "rgba(255,128,128,.5)",
       "dark": Object {
         "gutterIconPath": "images/gremlins-dark.svg",
@@ -646,6 +768,127 @@ Array [
 ]
 `;
 
+exports[`shows zero width non-joiner 1`] = `
+Array [
+  Array [
+    Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [
+      Object {
+        "hoverMessage": "1 zero width non-joiner (unicode U+200c) here",
+        "range": Object {
+          "left": Object {
+            "char": 22,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 23,
+            "line": 0,
+          },
+        },
+      },
+    ],
+  ],
+  Array [
+    Object {
+      "backgroundColor": "rgba(255,128,128,.5)",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "backgroundColor": "rgba(255,127,80,.5)",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "rgba(255,127,80,1)",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "backgroundColor": "rgba(255,127,80,.5)",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "rgba(255,127,80,1)",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
+  ],
+]
+`;
+
 exports[`shows zero width space 1`] = `
 Array [
   Array [
@@ -679,6 +922,24 @@ Array [
         },
       },
     ],
+  ],
+  Array [
+    Object {
+      "borderColor": "darkred",
+      "borderStyle": "solid",
+      "borderWidth": "1px",
+      "dark": Object {
+        "gutterIconPath": "images/gremlins-dark.svg",
+        "gutterIconSize": "75%",
+      },
+      "light": Object {
+        "gutterIconPath": "images/gremlins-light.svg",
+        "gutterIconSize": "75%",
+      },
+      "overviewRulerColor": "darkred",
+      "overviewRulerLane": "OverviewRulerLane.Right",
+    },
+    Array [],
   ],
   Array [
     Object {

--- a/extension.js
+++ b/extension.js
@@ -5,6 +5,10 @@ const gremlinsConfig = {
     zeroWidth: true,
     description: 'zero width space',
   },
+  '200c': {
+    zeroWidth: true,
+    description: 'zero width non-joiner',
+  },
   '00a0': {
     description: 'non breaking space',
   },

--- a/extension.test.js
+++ b/extension.test.js
@@ -53,6 +53,11 @@ it('shows zero width space', () => {
   activate(context)
   expect(mockSetDecorations.mock.calls).toMatchSnapshot()
 })
+it('shows zero width non-joiner', () => {
+  mockDocument.text = 'zero width non-joiner \u200c'
+  activate(context)
+  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+})
 
 it('shows non breaking space', () => {
   mockDocument.text = 'non breaking space \u00a0'
@@ -81,6 +86,7 @@ it('shows object replacement character', () => {
 it('shows multiple characters on multiple lines', () => {
   mockDocument.text = `
   zero width space \u200b\u200b\u200b
+  zero width non-joiner \u200c\u200c\u200c
   non breaking space \u00a0\u00a0\u00a0
   left double quotation mark \u201c\u201c\u201c
   right double quotation mark \u201d\u201d\u201d
@@ -92,6 +98,7 @@ it('shows multiple characters on multiple lines', () => {
 it('clears decorations with a clean document', () => {
   mockDocument.text = `
   zero width space \u200b\u200b\u200b
+  zero width non-joiner \u200c\u200c\u200c
   non breaking space \u00a0\u00a0\u00a0
   left double quotation mark \u201c\u201c\u201c
   right double quotation mark \u201d\u201d\u201d
@@ -101,6 +108,7 @@ it('clears decorations with a clean document', () => {
 
   mockDocument.text = `
   zero width space
+  zero width non-joiner
   non breaking space
   left double quotation mark
   right double quotation mark


### PR DESCRIPTION
When you copy `{` or `}` characters from Jira you can get ZERO WIDTH NON-JOINER (U+200C) char with it. 
And it could broke some translation tools if you use brackets for tokens.