### PR TITLE
Feature/detect settings changes (Fixes #56)

### DIFF
--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`clears decorations with a clean document 1`] = `
+exports[`updateDecorations clears decorations with a clean document 1`] = `
 Array [
   Array [
     Object {
@@ -195,7 +195,7 @@ Array [
 ]
 `;
 
-exports[`clears problems with a clean document 1`] = `
+exports[`updateDecorations clears problems with a clean document 1`] = `
 Array [
   Array [
     undefined,
@@ -204,7 +204,7 @@ Array [
 ]
 `;
 
-exports[`shows left double quotation mark 1`] = `
+exports[`updateDecorations shows left double quotation mark 1`] = `
 Array [
   Array [
     Object {
@@ -413,7 +413,7 @@ Array [
 ]
 `;
 
-exports[`shows left double quotation mark in problems 1`] = `
+exports[`updateDecorations shows left double quotation mark in problems 1`] = `
 Array [
   Array [
     undefined,
@@ -438,7 +438,7 @@ Array [
 ]
 `;
 
-exports[`shows multiple characters on multiple lines 1`] = `
+exports[`updateDecorations shows multiple characters on multiple lines 1`] = `
 Array [
   Array [
     Object {
@@ -475,11 +475,11 @@ Array [
         "hoverMessage": "3 non breaking spaces (unicode U+00a0) here",
         "range": Object {
           "left": Object {
-            "char": 21,
+            "char": 23,
             "line": 3,
           },
           "right": Object {
-            "char": 24,
+            "char": 26,
             "line": 3,
           },
         },
@@ -507,11 +507,11 @@ Array [
         "hoverMessage": "3 zero width spaces (unicode U+200b) here",
         "range": Object {
           "left": Object {
-            "char": 19,
+            "char": 21,
             "line": 1,
           },
           "right": Object {
-            "char": 22,
+            "char": 24,
             "line": 1,
           },
         },
@@ -539,11 +539,11 @@ Array [
         "hoverMessage": "3 zero width non-joiners (unicode U+200c) here",
         "range": Object {
           "left": Object {
-            "char": 24,
+            "char": 26,
             "line": 2,
           },
           "right": Object {
-            "char": 27,
+            "char": 29,
             "line": 2,
           },
         },
@@ -587,11 +587,11 @@ Array [
         "hoverMessage": "3 left double quotation marks (unicode U+201c) here",
         "range": Object {
           "left": Object {
-            "char": 29,
+            "char": 31,
             "line": 4,
           },
           "right": Object {
-            "char": 32,
+            "char": 34,
             "line": 4,
           },
         },
@@ -617,11 +617,11 @@ Array [
         "hoverMessage": "3 right double quotation marks (unicode U+201d) here",
         "range": Object {
           "left": Object {
-            "char": 30,
+            "char": 32,
             "line": 5,
           },
           "right": Object {
-            "char": 33,
+            "char": 35,
             "line": 5,
           },
         },
@@ -703,7 +703,7 @@ Array [
 ]
 `;
 
-exports[`shows multiple characters on multiple lines in problems 1`] = `
+exports[`updateDecorations shows multiple characters on multiple lines in problems 1`] = `
 Array [
   Array [
     undefined,
@@ -712,11 +712,11 @@ Array [
         "message": "3 zero width spaces (unicode U+200b) here",
         "range": Object {
           "left": Object {
-            "char": 19,
+            "char": 21,
             "line": 1,
           },
           "right": Object {
-            "char": 22,
+            "char": 24,
             "line": 1,
           },
         },
@@ -727,11 +727,11 @@ Array [
         "message": "3 zero width non-joiners (unicode U+200c) here",
         "range": Object {
           "left": Object {
-            "char": 24,
+            "char": 26,
             "line": 2,
           },
           "right": Object {
-            "char": 27,
+            "char": 29,
             "line": 2,
           },
         },
@@ -742,11 +742,11 @@ Array [
         "message": "3 non breaking spaces (unicode U+00a0) here",
         "range": Object {
           "left": Object {
-            "char": 21,
+            "char": 23,
             "line": 3,
           },
           "right": Object {
-            "char": 24,
+            "char": 26,
             "line": 3,
           },
         },
@@ -757,11 +757,11 @@ Array [
         "message": "3 left double quotation marks (unicode U+201c) here",
         "range": Object {
           "left": Object {
-            "char": 29,
+            "char": 31,
             "line": 4,
           },
           "right": Object {
-            "char": 32,
+            "char": 34,
             "line": 4,
           },
         },
@@ -772,11 +772,11 @@ Array [
         "message": "3 right double quotation marks (unicode U+201d) here",
         "range": Object {
           "left": Object {
-            "char": 30,
+            "char": 32,
             "line": 5,
           },
           "right": Object {
-            "char": 33,
+            "char": 35,
             "line": 5,
           },
         },
@@ -788,7 +788,7 @@ Array [
 ]
 `;
 
-exports[`shows non breaking space 1`] = `
+exports[`updateDecorations shows non breaking space 1`] = `
 Array [
   Array [
     Object {
@@ -997,7 +997,7 @@ Array [
 ]
 `;
 
-exports[`shows non breaking space in problems 1`] = `
+exports[`updateDecorations shows non breaking space in problems 1`] = `
 Array [
   Array [
     undefined,
@@ -1022,7 +1022,7 @@ Array [
 ]
 `;
 
-exports[`shows object replacement character 1`] = `
+exports[`updateDecorations shows object replacement character 1`] = `
 Array [
   Array [
     Object {
@@ -1231,7 +1231,7 @@ Array [
 ]
 `;
 
-exports[`shows object replacement character in problems 1`] = `
+exports[`updateDecorations shows object replacement character in problems 1`] = `
 Array [
   Array [
     undefined,
@@ -1256,7 +1256,7 @@ Array [
 ]
 `;
 
-exports[`shows right double quotation mark 1`] = `
+exports[`updateDecorations shows right double quotation mark 1`] = `
 Array [
   Array [
     Object {
@@ -1465,7 +1465,7 @@ Array [
 ]
 `;
 
-exports[`shows right double quotation mark in problems 1`] = `
+exports[`updateDecorations shows right double quotation mark in problems 1`] = `
 Array [
   Array [
     undefined,
@@ -1490,7 +1490,7 @@ Array [
 ]
 `;
 
-exports[`shows zero width non-joiner 1`] = `
+exports[`updateDecorations shows zero width non-joiner 1`] = `
 Array [
   Array [
     Object {
@@ -1699,7 +1699,7 @@ Array [
 ]
 `;
 
-exports[`shows zero width non-joiner in problems 1`] = `
+exports[`updateDecorations shows zero width non-joiner in problems 1`] = `
 Array [
   Array [
     undefined,
@@ -1724,7 +1724,7 @@ Array [
 ]
 `;
 
-exports[`shows zero width space 1`] = `
+exports[`updateDecorations shows zero width space 1`] = `
 Array [
   Array [
     Object {
@@ -1933,7 +1933,7 @@ Array [
 ]
 `;
 
-exports[`shows zero width space in problems 1`] = `
+exports[`updateDecorations shows zero width space in problems 1`] = `
 Array [
   Array [
     undefined,

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lifecycle registers with window.onDidChangeActiveTextEditor 1`] = `
+Array [
+  Array [
+    [Function],
+    null,
+    undefined,
+  ],
+]
+`;
+
+exports[`lifecycle registers with window.onDidChangeActiveTextEditor 2`] = `"editor => updateDecorations(editor, gremlins, regexpWithAllChars, diagnosticCollection)"`;
+
+exports[`lifecycle registers with window.onDidChangeTextEditorSelection 1`] = `
+Array [
+  Array [
+    [Function],
+    null,
+    undefined,
+  ],
+]
+`;
+
+exports[`lifecycle registers with window.onDidChangeTextEditorSelection 2`] = `"event => updateDecorations(event.textEditor, gremlins, egexpWithAllChars, diagnosticCollection)"`;
+
+exports[`lifecycle registers with workspace.onDidChangeTextDocument 1`] = `
+Array [
+  Array [
+    [Function],
+    null,
+    undefined,
+  ],
+]
+`;
+
+exports[`lifecycle registers with workspace.onDidChangeTextDocument 2`] = `"event => updateDecorations(vscode.window.activeTextEditor, gremlins, regexpWithAllChars, diagnosticCollection)"`;
+
+exports[`lifecycle registers with workspace.onDidCloseTextDocument 1`] = `
+Array [
+  Array [
+    [Function],
+    null,
+    undefined,
+  ],
+]
+`;
+
+exports[`lifecycle registers with workspace.onDidCloseTextDocument 2`] = `"textDocument => diagnosticCollection.delete(textDocument.uri)"`;
+
 exports[`updateDecorations clears decorations with a clean document 1`] = `
 Array [
   Array [

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -1,6 +1,1813 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lifecycle registers with window.onDidChangeActiveTextEditor 1`] = `
+exports[`lifecycle event handling clears diagnostics on workspace.onDidCloseTextDocument 1`] = `undefined`;
+
+exports[`lifecycle event handling processes new file on window.onDidChangeActiveTextEditor 1`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [
+      Object {
+        "hoverMessage": "1 zero width space (unicode U+200b) here",
+        "range": Object {
+          "left": Object {
+            "char": 17,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 18,
+            "line": 0,
+          },
+        },
+      },
+    ],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+]
+`;
+
+exports[`lifecycle event handling processes new file on window.onDidChangeActiveTextEditor 2`] = `
+Array [
+  Array [
+    undefined,
+    Array [
+      Object {
+        "message": "1 zero width space (unicode U+200b) here",
+        "range": Object {
+          "left": Object {
+            "char": 17,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 18,
+            "line": 0,
+          },
+        },
+        "severity": "DiagnosticSeverity.Error",
+        "source": "Gremlins tracker",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`lifecycle event handling processes new file on window.onDidChangeTextEditorSelection 1`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [
+      Object {
+        "hoverMessage": "1 zero width space (unicode U+200b) here",
+        "range": Object {
+          "left": Object {
+            "char": 17,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 18,
+            "line": 0,
+          },
+        },
+      },
+    ],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+]
+`;
+
+exports[`lifecycle event handling processes new file on window.onDidChangeTextEditorSelection 2`] = `
+Array [
+  Array [
+    undefined,
+    Array [
+      Object {
+        "message": "1 zero width space (unicode U+200b) here",
+        "range": Object {
+          "left": Object {
+            "char": 17,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 18,
+            "line": 0,
+          },
+        },
+        "severity": "DiagnosticSeverity.Error",
+        "source": "Gremlins tracker",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`lifecycle event handling processes new file on workspace.onDidChangeTextDocument 1`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [
+      Object {
+        "hoverMessage": "1 zero width space (unicode U+200b) here",
+        "range": Object {
+          "left": Object {
+            "char": 17,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 18,
+            "line": 0,
+          },
+        },
+      },
+    ],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+]
+`;
+
+exports[`lifecycle event handling processes new file on workspace.onDidChangeTextDocument 2`] = `
+Array [
+  Array [
+    undefined,
+    Array [
+      Object {
+        "message": "1 zero width space (unicode U+200b) here",
+        "range": Object {
+          "left": Object {
+            "char": 17,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 18,
+            "line": 0,
+          },
+        },
+        "severity": "DiagnosticSeverity.Error",
+        "source": "Gremlins tracker",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`lifecycle event handling processes visible text editors on workspace.onDidChangeConfiguration 1`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+]
+`;
+
+exports[`lifecycle event handling processes visible text editors on workspace.onDidChangeConfiguration 2`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+]
+`;
+
+exports[`lifecycle event handling processes visible text editors on workspace.onDidChangeConfiguration 3`] = `
+Array [
+  Array [
+    undefined,
+    Array [],
+  ],
+  Array [
+    undefined,
+    Array [],
+  ],
+]
+`;
+
+exports[`lifecycle registration registers with window.onDidChangeActiveTextEditor 1`] = `
 Array [
   Array [
     [Function],
@@ -10,7 +1817,7 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with window.onDidChangeTextEditorSelection 1`] = `
+exports[`lifecycle registration registers with window.onDidChangeTextEditorSelection 1`] = `
 Array [
   Array [
     [Function],
@@ -20,7 +1827,7 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with workspace.onDidChangeConfiguration 1`] = `
+exports[`lifecycle registration registers with workspace.onDidChangeConfiguration 1`] = `
 Array [
   Array [
     [Function],
@@ -30,7 +1837,7 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with workspace.onDidChangeTextDocument 1`] = `
+exports[`lifecycle registration registers with workspace.onDidChangeTextDocument 1`] = `
 Array [
   Array [
     [Function],
@@ -40,7 +1847,7 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with workspace.onDidCloseTextDocument 1`] = `
+exports[`lifecycle registration registers with workspace.onDidCloseTextDocument 1`] = `
 Array [
   Array [
     [Function],

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -475,11 +475,11 @@ Array [
         "hoverMessage": "3 non breaking spaces (unicode U+00a0) here",
         "range": Object {
           "left": Object {
-            "char": 23,
+            "char": 19,
             "line": 3,
           },
           "right": Object {
-            "char": 26,
+            "char": 22,
             "line": 3,
           },
         },
@@ -507,11 +507,11 @@ Array [
         "hoverMessage": "3 zero width spaces (unicode U+200b) here",
         "range": Object {
           "left": Object {
-            "char": 21,
+            "char": 17,
             "line": 1,
           },
           "right": Object {
-            "char": 24,
+            "char": 20,
             "line": 1,
           },
         },
@@ -539,11 +539,11 @@ Array [
         "hoverMessage": "3 zero width non-joiners (unicode U+200c) here",
         "range": Object {
           "left": Object {
-            "char": 26,
+            "char": 22,
             "line": 2,
           },
           "right": Object {
-            "char": 29,
+            "char": 25,
             "line": 2,
           },
         },
@@ -587,11 +587,11 @@ Array [
         "hoverMessage": "3 left double quotation marks (unicode U+201c) here",
         "range": Object {
           "left": Object {
-            "char": 31,
+            "char": 27,
             "line": 4,
           },
           "right": Object {
-            "char": 34,
+            "char": 30,
             "line": 4,
           },
         },
@@ -617,11 +617,11 @@ Array [
         "hoverMessage": "3 right double quotation marks (unicode U+201d) here",
         "range": Object {
           "left": Object {
-            "char": 32,
+            "char": 28,
             "line": 5,
           },
           "right": Object {
-            "char": 35,
+            "char": 31,
             "line": 5,
           },
         },
@@ -712,11 +712,11 @@ Array [
         "message": "3 zero width spaces (unicode U+200b) here",
         "range": Object {
           "left": Object {
-            "char": 21,
+            "char": 17,
             "line": 1,
           },
           "right": Object {
-            "char": 24,
+            "char": 20,
             "line": 1,
           },
         },
@@ -727,11 +727,11 @@ Array [
         "message": "3 zero width non-joiners (unicode U+200c) here",
         "range": Object {
           "left": Object {
-            "char": 26,
+            "char": 22,
             "line": 2,
           },
           "right": Object {
-            "char": 29,
+            "char": 25,
             "line": 2,
           },
         },
@@ -742,11 +742,11 @@ Array [
         "message": "3 non breaking spaces (unicode U+00a0) here",
         "range": Object {
           "left": Object {
-            "char": 23,
+            "char": 19,
             "line": 3,
           },
           "right": Object {
-            "char": 26,
+            "char": 22,
             "line": 3,
           },
         },
@@ -757,11 +757,11 @@ Array [
         "message": "3 left double quotation marks (unicode U+201c) here",
         "range": Object {
           "left": Object {
-            "char": 31,
+            "char": 27,
             "line": 4,
           },
           "right": Object {
-            "char": 34,
+            "char": 30,
             "line": 4,
           },
         },
@@ -772,11 +772,11 @@ Array [
         "message": "3 right double quotation marks (unicode U+201d) here",
         "range": Object {
           "left": Object {
-            "char": 32,
+            "char": 28,
             "line": 5,
           },
           "right": Object {
-            "char": 35,
+            "char": 31,
             "line": 5,
           },
         },

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -10,7 +10,7 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with window.onDidChangeActiveTextEditor 2`] = `"editor => updateDecorations(editor, gremlins, regexpWithAllChars, diagnosticCollection)"`;
+exports[`lifecycle registers with window.onDidChangeActiveTextEditor 2`] = `"editor => doUpdateDecorations(editor)"`;
 
 exports[`lifecycle registers with window.onDidChangeTextEditorSelection 1`] = `
 Array [
@@ -22,7 +22,29 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with window.onDidChangeTextEditorSelection 2`] = `"event => updateDecorations(event.textEditor, gremlins, egexpWithAllChars, diagnosticCollection)"`;
+exports[`lifecycle registers with window.onDidChangeTextEditorSelection 2`] = `"event => doUpdateDecorations(event.textEditor)"`;
+
+exports[`lifecycle registers with workspace.onDidChangeConfiguration 1`] = `
+Array [
+  Array [
+    [Function],
+    null,
+    undefined,
+  ],
+]
+`;
+
+exports[`lifecycle registers with workspace.onDidChangeConfiguration 2`] = `
+"event => {
+    if (event.affectsConfiguration(GREMLINS)) {
+      disposeOldDecorations(configuration.gremlins);
+      gremlinsConfiguration = vscode.workspace.getConfiguration(GREMLINS);
+      configuration = loadConfiguration(gremlinsConfiguration, context);
+      diagnosticCollection = configurDiagnosticsCollection(configuration.showDiagnostics);
+      vscode.window.visibleTextEditors.forEach(editor => doUpdateDecorations(editor));
+    }
+  }"
+`;
 
 exports[`lifecycle registers with workspace.onDidChangeTextDocument 1`] = `
 Array [
@@ -34,7 +56,7 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with workspace.onDidChangeTextDocument 2`] = `"event => updateDecorations(vscode.window.activeTextEditor, gremlins, regexpWithAllChars, diagnosticCollection)"`;
+exports[`lifecycle registers with workspace.onDidChangeTextDocument 2`] = `"event => doUpdateDecorations(vscode.window.activeTextEditor)"`;
 
 exports[`lifecycle registers with workspace.onDidCloseTextDocument 1`] = `
 Array [
@@ -46,7 +68,7 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with workspace.onDidCloseTextDocument 2`] = `"textDocument => diagnosticCollection.delete(textDocument.uri)"`;
+exports[`lifecycle registers with workspace.onDidCloseTextDocument 2`] = `"textDocument => diagnosticCollection && diagnosticCollection.delete(textDocument.uri)"`;
 
 exports[`updateDecorations clears decorations with a clean document 1`] = `
 Array [

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -10,8 +10,6 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with window.onDidChangeActiveTextEditor 2`] = `"editor => doUpdateDecorations(editor)"`;
-
 exports[`lifecycle registers with window.onDidChangeTextEditorSelection 1`] = `
 Array [
   Array [
@@ -22,8 +20,6 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with window.onDidChangeTextEditorSelection 2`] = `"event => doUpdateDecorations(event.textEditor)"`;
-
 exports[`lifecycle registers with workspace.onDidChangeConfiguration 1`] = `
 Array [
   Array [
@@ -32,18 +28,6 @@ Array [
     undefined,
   ],
 ]
-`;
-
-exports[`lifecycle registers with workspace.onDidChangeConfiguration 2`] = `
-"event => {
-    if (event.affectsConfiguration(GREMLINS)) {
-      disposeOldDecorations(configuration.gremlins);
-      gremlinsConfiguration = vscode.workspace.getConfiguration(GREMLINS);
-      configuration = loadConfiguration(gremlinsConfiguration, context);
-      diagnosticCollection = configurDiagnosticsCollection(configuration.showDiagnostics);
-      vscode.window.visibleTextEditors.forEach(editor => doUpdateDecorations(editor));
-    }
-  }"
 `;
 
 exports[`lifecycle registers with workspace.onDidChangeTextDocument 1`] = `
@@ -56,8 +40,6 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with workspace.onDidChangeTextDocument 2`] = `"event => doUpdateDecorations(vscode.window.activeTextEditor)"`;
-
 exports[`lifecycle registers with workspace.onDidCloseTextDocument 1`] = `
 Array [
   Array [
@@ -68,197 +50,71 @@ Array [
 ]
 `;
 
-exports[`lifecycle registers with workspace.onDidCloseTextDocument 2`] = `"textDocument => diagnosticCollection && diagnosticCollection.delete(textDocument.uri)"`;
-
 exports[`updateDecorations clears decorations with a clean document 1`] = `
 Array [
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
@@ -278,103 +134,37 @@ exports[`updateDecorations shows left double quotation mark 1`] = `
 Array [
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -394,89 +184,31 @@ Array [
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
@@ -512,33 +244,13 @@ exports[`updateDecorations shows multiple characters on multiple lines 1`] = `
 Array [
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -558,19 +270,7 @@ Array [
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -590,19 +290,7 @@ Array [
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -622,35 +310,13 @@ Array [
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -670,17 +336,7 @@ Array [
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -700,73 +356,25 @@ Array [
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
@@ -862,33 +470,13 @@ exports[`updateDecorations shows non breaking space 1`] = `
 Array [
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -908,159 +496,55 @@ Array [
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
@@ -1096,191 +580,67 @@ exports[`updateDecorations shows object replacement character 1`] = `
 Array [
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -1330,119 +690,43 @@ exports[`updateDecorations shows right double quotation mark 1`] = `
 Array [
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -1462,73 +746,25 @@ Array [
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
@@ -1564,69 +800,25 @@ exports[`updateDecorations shows zero width non-joiner 1`] = `
 Array [
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -1646,123 +838,43 @@ Array [
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
@@ -1798,51 +910,19 @@ exports[`updateDecorations shows zero width space 1`] = `
 Array [
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [
       Object {
@@ -1862,141 +942,49 @@ Array [
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "backgroundColor": "rgba(169, 68, 66, .75)",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],
   Array [
     Object {
-      "borderColor": "rgba(169, 68, 66, .75)",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "dark": Object {
-        "gutterIconPath": "images/gremlins-dark.svg",
-        "gutterIconSize": "75%",
-      },
-      "light": Object {
-        "gutterIconPath": "images/gremlins-light.svg",
-        "gutterIconSize": "75%",
-      },
-      "overviewRulerColor": "rgba(169, 68, 66, .75)",
-      "overviewRulerLane": "OverviewRulerLane.Right",
+      "dispose": [MockFunction],
     },
     Array [],
   ],

--- a/extension.js
+++ b/extension.js
@@ -271,5 +271,6 @@ function dispose() {
     diagnosticCollection.dispose()
   }
   listeners.forEach(listener => listener.dispose())
+  listeners.length = 0
 }
 exports.dispose = dispose

--- a/extension.js
+++ b/extension.js
@@ -213,7 +213,7 @@ function activate(context) {
   )
 
   vscode.workspace.onDidCloseTextDocument(
-    textDocument => diagnosticCollection && diagnosticCollection.delete(textDocument.uri),
+    textDocument => diagnosticCollection.delete(textDocument.uri),
     null,
     context.subscriptions
   )

--- a/extension.js
+++ b/extension.js
@@ -18,7 +18,7 @@ const GREMLINS_SEVERITIES = {
 
 let diagnosticCollection = null
 
-function configurDiagnosticsCollection(showDiagnostics) {
+function configureDiagnosticsCollection(showDiagnostics) {
   if (showDiagnostics && !diagnosticCollection) {
     diagnosticCollection = diagnosticCollection = vscode.languages.createDiagnosticCollection(GREMLINS)
   } else if (!showDiagnostics && diagnosticCollection) {
@@ -29,7 +29,7 @@ function configurDiagnosticsCollection(showDiagnostics) {
   return diagnosticCollection
 }
 
-function disposeOldDecorations(gremlins) {
+function disposeDecorationTypes(gremlins) {
   Object.entries(gremlins).forEach(([_, config]) => config.decorationType.dispose())
 }
 
@@ -200,7 +200,7 @@ const listeners = []
 function activate(context) {
   let gremlinsConfiguration = vscode.workspace.getConfiguration(GREMLINS)
   let configuration = loadConfiguration(gremlinsConfiguration, context)
-  let diagnosticCollection = configurDiagnosticsCollection(configuration.showDiagnostics)
+  let diagnosticCollection = configureDiagnosticsCollection(configuration.showDiagnostics)
 
   const doUpdateDecorations = editor => updateDecorations(
     editor,
@@ -245,10 +245,10 @@ function activate(context) {
     vscode.workspace.onDidChangeConfiguration(
       event => {
         if (event.affectsConfiguration(GREMLINS)) {
-          disposeOldDecorations(configuration.gremlins)
+          disposeDecorationTypes(configuration.gremlins)
           gremlinsConfiguration = vscode.workspace.getConfiguration(GREMLINS)
           configuration = loadConfiguration(gremlinsConfiguration, context)
-          diagnosticCollection = configurDiagnosticsCollection(configuration.showDiagnostics)
+          diagnosticCollection = configureDiagnosticsCollection(configuration.showDiagnostics)
           vscode.window.visibleTextEditors.forEach(editor => doUpdateDecorations(editor))
         }
       },

--- a/extension.js
+++ b/extension.js
@@ -263,10 +263,7 @@ function activate(context) {
 exports.activate = activate
 
 // this method is called when your extension is deactivated
-function deactivate() {}
-exports.deactivate = deactivate
-
-function dispose() {
+function deactivate() {
   if (diagnosticCollection) {
     diagnosticCollection.clear()
     diagnosticCollection.dispose()
@@ -275,4 +272,4 @@ function dispose() {
   listeners.forEach(listener => listener.dispose())
   listeners.length = 0
 }
-exports.dispose = dispose
+exports.deactivate = deactivate

--- a/extension.js
+++ b/extension.js
@@ -271,7 +271,9 @@ function deactivate() {
     diagnosticCollection.clear()
     diagnosticCollection.dispose()
   }
+
   disposeDecorationTypes(configuration.gremlins)
+  
   listeners.forEach(listener => listener.dispose())
   listeners.length = 0
 }

--- a/extension.js
+++ b/extension.js
@@ -197,9 +197,10 @@ function updateDecorations(activeTextEditor, gremlins, regexpWithAllChars, diagn
 }
 
 const listeners = []
+let configuration
 function activate(context) {
   let gremlinsConfiguration = vscode.workspace.getConfiguration(GREMLINS)
-  let configuration = loadConfiguration(gremlinsConfiguration, context)
+  configuration = loadConfiguration(gremlinsConfiguration, context)
   let diagnosticCollection = configureDiagnosticsCollection(configuration.showDiagnostics)
 
   const doUpdateDecorations = editor => updateDecorations(
@@ -270,6 +271,7 @@ function dispose() {
     diagnosticCollection.clear()
     diagnosticCollection.dispose()
   }
+  disposeDecorationTypes(configuration.gremlins)
   listeners.forEach(listener => listener.dispose())
   listeners.length = 0
 }

--- a/extension.js
+++ b/extension.js
@@ -30,7 +30,10 @@ function configureDiagnosticsCollection(showDiagnostics) {
 }
 
 function disposeDecorationTypes(gremlins) {
-  Object.entries(gremlins).forEach(([_, config]) => config.decorationType.dispose())
+  Object.entries(gremlins).forEach(([key, config]) => {
+    config.decorationType.dispose()
+    delete gremlins[key]
+  })
 }
 
 function loadConfiguration(gremlinsConfiguration, context) {

--- a/extension.test.js
+++ b/extension.test.js
@@ -13,6 +13,10 @@ let mockDisposable = {
   dispose: jest.fn()
 }
 
+let mockDecorationType = {
+  dispose: jest.fn()
+}
+
 const mockSetDecorations = jest.fn()
 const mockSetDiagnostics = jest.fn()
 const mockClearDiagnostics = jest.fn()
@@ -45,7 +49,7 @@ jest.mock(
       window: {
         onDidChangeActiveTextEditor: jest.fn(() => mockDisposable),
         onDidChangeTextEditorSelection: jest.fn(() => mockDisposable),
-        createTextEditorDecorationType: jest.fn(arg => arg),
+        createTextEditorDecorationType: jest.fn(() => mockDecorationType),
         activeTextEditor: {
           document: mockDocument,
           setDecorations: mockSetDecorations,
@@ -284,6 +288,8 @@ describe('lifecycle', () => {
   })
 
   it('clears and then disposes diagnostics when extension is disposed', () => {
+    const packageData = require('./package.json')
+
     activate(context)
 
     dispose()
@@ -292,5 +298,6 @@ describe('lifecycle', () => {
     const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0]
     expect(clearCallOrder).toBeLessThan(disposeCallOrder)
     expect(mockDisposable.dispose.mock.calls.length).toBe(5)
+    expect(mockDecorationType.dispose.mock.calls.length).toBe(mockVscode.window.createTextEditorDecorationType.mock.calls.length)
   })
 })

--- a/extension.test.js
+++ b/extension.test.js
@@ -46,7 +46,7 @@ jest.mock(
         }),
       },
       languages: {
-        createDiagnosticCollection: jest.fn(key => ({ 
+        createDiagnosticCollection: jest.fn(key => ({
           set: mockSetDiagnostics,
           delete: mockDeleteDiagnostics,
           clear: mockClearDiagnostics,
@@ -70,6 +70,7 @@ jest.mock(
   { virtual: true },
 )
 
+const mockVscode = require('vscode')
 const { activate, dispose } = require('./extension')
 const context = {
   asAbsolutePath: arg => arg,

--- a/extension.test.js
+++ b/extension.test.js
@@ -15,6 +15,25 @@ const mockClearDiagnostics = jest.fn()
 const mockDeleteDiagnostics = jest.fn()
 const mockDisposeDiagnostics = jest.fn()
 
+/**
+ * Tag for use with template literals
+ * 
+ * Finds the indentation on the first line after the opening backtick
+ * and removes that indentation from every line in the template.
+ * @param {String[]} strings Array of lines in the template literal
+ */
+function outdent(strings) {
+  // Add in all of the expressions
+  let outdented = strings.map((s, i) => `${s}${arguments[i+1]||''}`).join('')
+  // Find the indentation after the first newline
+  const matches = /^\s+/.exec(outdented.split('\n')[1])
+  if (matches) {
+    const outdentRegex = new RegExp('\\n' + matches[0], 'g')
+    outdented = outdented.replace(outdentRegex, '\n')
+  }
+  return outdented
+}
+
 jest.mock(
   'vscode',
   () => {
@@ -154,7 +173,7 @@ describe('updateDecorations', () => {
   })
 
   it('shows multiple characters on multiple lines', () => {
-    mockDocument.text = `
+    mockDocument.text = outdent`
     zero width space \u200b\u200b\u200b
     zero width non-joiner \u200c\u200c\u200c
     non breaking space \u00a0\u00a0\u00a0
@@ -166,7 +185,7 @@ describe('updateDecorations', () => {
   })
 
   it('shows multiple characters on multiple lines in problems', () => {
-    mockDocument.text = `
+    mockDocument.text = outdent`
     zero width space \u200b\u200b\u200b
     zero width non-joiner \u200c\u200c\u200c
     non breaking space \u00a0\u00a0\u00a0
@@ -178,7 +197,7 @@ describe('updateDecorations', () => {
   })
 
   it('clears decorations with a clean document', () => {
-    mockDocument.text = `
+    mockDocument.text = outdent`
     zero width space \u200b\u200b\u200b
     zero width non-joiner \u200c\u200c\u200c
     non breaking space \u00a0\u00a0\u00a0
@@ -188,7 +207,7 @@ describe('updateDecorations', () => {
     activate(context)
     mockSetDecorations.mockClear()
 
-    mockDocument.text = `
+    mockDocument.text = outdent`
     zero width space
     zero width non-joiner
     non breaking space
@@ -201,7 +220,7 @@ describe('updateDecorations', () => {
   })
 
   it('clears problems with a clean document', () => {
-    mockDocument.text = `
+    mockDocument.text = outdent`
     zero width space \u200b\u200b\u200b
     zero width non-joiner \u200c\u200c\u200c
     non breaking space \u00a0\u00a0\u00a0
@@ -211,7 +230,7 @@ describe('updateDecorations', () => {
     activate(context)
     mockSetDiagnostics.mockClear()
 
-    mockDocument.text = `
+    mockDocument.text = outdent`
     zero width space
     zero width non-joiner
     non breaking space
@@ -228,8 +247,8 @@ describe('lifecycle', () => {
   it('clears and then disposes diagnostics when extension is disposed', () => {
     dispose()
 
-    const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0];
-    const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0];
-    expect(clearCallOrder).toBeLessThan(disposeCallOrder);
+    const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0]
+    const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0]
+    expect(clearCallOrder).toBeLessThan(disposeCallOrder)
   })
 })

--- a/extension.test.js
+++ b/extension.test.js
@@ -244,6 +244,34 @@ describe('updateDecorations', () => {
 })
 
 describe('lifecycle', () => {
+  it('registers with window.onDidChangeActiveTextEditor', () => {
+    activate(context)
+
+    expect(mockVscode.window.onDidChangeActiveTextEditor.mock.calls).toMatchSnapshot()
+    expect(mockVscode.window.onDidChangeActiveTextEditor.mock.calls[0][0].toString()).toMatchSnapshot()
+  })
+
+  it('registers with window.onDidChangeTextEditorSelection', () => {
+    activate(context)
+
+    expect(mockVscode.window.onDidChangeTextEditorSelection.mock.calls).toMatchSnapshot()
+    expect(mockVscode.window.onDidChangeTextEditorSelection.mock.calls[0][0].toString()).toMatchSnapshot()
+  })
+
+  it('registers with workspace.onDidChangeTextDocument', () => {
+    activate(context)
+
+    expect(mockVscode.workspace.onDidChangeTextDocument.mock.calls).toMatchSnapshot()
+    expect(mockVscode.workspace.onDidChangeTextDocument.mock.calls[0][0].toString()).toMatchSnapshot()
+  })
+
+  it('registers with workspace.onDidCloseTextDocument', () => {
+    activate(context)
+
+    expect(mockVscode.workspace.onDidCloseTextDocument.mock.calls).toMatchSnapshot()
+    expect(mockVscode.workspace.onDidCloseTextDocument.mock.calls[0][0].toString()).toMatchSnapshot()
+  })
+
   it('clears and then disposes diagnostics when extension is disposed', () => {
     dispose()
 

--- a/extension.test.js
+++ b/extension.test.js
@@ -80,152 +80,156 @@ beforeEach(() => {
   jest.clearAllMocks()
 })
 
-it('shows zero width space', () => {
-  mockDocument.text = 'zero width space \u200b'
-  activate(context)
-  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+describe('updateDecorations', () => {
+  it('shows zero width space', () => {
+    mockDocument.text = 'zero width space \u200b'
+    activate(context)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows zero width space in problems', () => {
+    mockDocument.text = 'zero width space \u200b'
+    activate(context)
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows zero width non-joiner', () => {
+    mockDocument.text = 'zero width non-joiner \u200c'
+    activate(context)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows zero width non-joiner in problems', () => {
+    mockDocument.text = 'zero width non-joiner \u200c'
+    activate(context)
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows non breaking space', () => {
+    mockDocument.text = 'non breaking space \u00a0'
+    activate(context)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows non breaking space in problems', () => {
+    mockDocument.text = 'non breaking space \u00a0'
+    activate(context)
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows left double quotation mark', () => {
+    mockDocument.text = 'left double quotation mark \u201c'
+    activate(context)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows left double quotation mark in problems', () => {
+    mockDocument.text = 'left double quotation mark \u201c'
+    activate(context)
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows right double quotation mark', () => {
+    mockDocument.text = 'right double quotation mark \u201d'
+    activate(context)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows right double quotation mark in problems', () => {
+    mockDocument.text = 'right double quotation mark \u201d'
+    activate(context)
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows object replacement character', () => {
+    mockDocument.text = 'object replacement character \ufffc'
+    activate(context)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows object replacement character in problems', () => {
+    mockDocument.text = 'object replacement character \ufffc'
+    activate(context)
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows multiple characters on multiple lines', () => {
+    mockDocument.text = `
+    zero width space \u200b\u200b\u200b
+    zero width non-joiner \u200c\u200c\u200c
+    non breaking space \u00a0\u00a0\u00a0
+    left double quotation mark \u201c\u201c\u201c
+    right double quotation mark \u201d\u201d\u201d
+    `
+    activate(context)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows multiple characters on multiple lines in problems', () => {
+    mockDocument.text = `
+    zero width space \u200b\u200b\u200b
+    zero width non-joiner \u200c\u200c\u200c
+    non breaking space \u00a0\u00a0\u00a0
+    left double quotation mark \u201c\u201c\u201c
+    right double quotation mark \u201d\u201d\u201d
+    `
+    activate(context)
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+
+  it('clears decorations with a clean document', () => {
+    mockDocument.text = `
+    zero width space \u200b\u200b\u200b
+    zero width non-joiner \u200c\u200c\u200c
+    non breaking space \u00a0\u00a0\u00a0
+    left double quotation mark \u201c\u201c\u201c
+    right double quotation mark \u201d\u201d\u201d
+    `
+    activate(context)
+    mockSetDecorations.mockClear()
+
+    mockDocument.text = `
+    zero width space
+    zero width non-joiner
+    non breaking space
+    left double quotation mark
+    right double quotation mark
+    `
+    activate(context)
+
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('clears problems with a clean document', () => {
+    mockDocument.text = `
+    zero width space \u200b\u200b\u200b
+    zero width non-joiner \u200c\u200c\u200c
+    non breaking space \u00a0\u00a0\u00a0
+    left double quotation mark \u201c\u201c\u201c
+    right double quotation mark \u201d\u201d\u201d
+    `
+    activate(context)
+    mockSetDiagnostics.mockClear()
+
+    mockDocument.text = `
+    zero width space
+    zero width non-joiner
+    non breaking space
+    left double quotation mark
+    right double quotation mark
+    `
+    activate(context)
+
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
 })
 
-it('shows zero width space in problems', () => {
-  mockDocument.text = 'zero width space \u200b'
-  activate(context)
-  expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
-})
+describe('lifecycle', () => {
+  it('clears and then disposes diagnostics when extension is disposed', () => {
+    dispose()
 
-it('shows zero width non-joiner', () => {
-  mockDocument.text = 'zero width non-joiner \u200c'
-  activate(context)
-  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
-})
-
-it('shows zero width non-joiner in problems', () => {
-  mockDocument.text = 'zero width non-joiner \u200c'
-  activate(context)
-  expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
-})
-
-it('shows non breaking space', () => {
-  mockDocument.text = 'non breaking space \u00a0'
-  activate(context)
-  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
-})
-
-it('shows non breaking space in problems', () => {
-  mockDocument.text = 'non breaking space \u00a0'
-  activate(context)
-  expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
-})
-
-it('shows left double quotation mark', () => {
-  mockDocument.text = 'left double quotation mark \u201c'
-  activate(context)
-  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
-})
-
-it('shows left double quotation mark in problems', () => {
-  mockDocument.text = 'left double quotation mark \u201c'
-  activate(context)
-  expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
-})
-
-it('shows right double quotation mark', () => {
-  mockDocument.text = 'right double quotation mark \u201d'
-  activate(context)
-  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
-})
-
-it('shows right double quotation mark in problems', () => {
-  mockDocument.text = 'right double quotation mark \u201d'
-  activate(context)
-  expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
-})
-
-it('shows object replacement character', () => {
-  mockDocument.text = 'object replacement character \ufffc'
-  activate(context)
-  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
-})
-
-it('shows object replacement character in problems', () => {
-  mockDocument.text = 'object replacement character \ufffc'
-  activate(context)
-  expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
-})
-
-it('shows multiple characters on multiple lines', () => {
-  mockDocument.text = `
-  zero width space \u200b\u200b\u200b
-  zero width non-joiner \u200c\u200c\u200c
-  non breaking space \u00a0\u00a0\u00a0
-  left double quotation mark \u201c\u201c\u201c
-  right double quotation mark \u201d\u201d\u201d
-  `
-  activate(context)
-  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
-})
-
-it('shows multiple characters on multiple lines in problems', () => {
-  mockDocument.text = `
-  zero width space \u200b\u200b\u200b
-  zero width non-joiner \u200c\u200c\u200c
-  non breaking space \u00a0\u00a0\u00a0
-  left double quotation mark \u201c\u201c\u201c
-  right double quotation mark \u201d\u201d\u201d
-  `
-  activate(context)
-  expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
-})
-
-it('clears decorations with a clean document', () => {
-  mockDocument.text = `
-  zero width space \u200b\u200b\u200b
-  zero width non-joiner \u200c\u200c\u200c
-  non breaking space \u00a0\u00a0\u00a0
-  left double quotation mark \u201c\u201c\u201c
-  right double quotation mark \u201d\u201d\u201d
-  `
-  activate(context)
-  mockSetDecorations.mockClear()
-
-  mockDocument.text = `
-  zero width space
-  zero width non-joiner
-  non breaking space
-  left double quotation mark
-  right double quotation mark
-  `
-  activate(context)
-
-  expect(mockSetDecorations.mock.calls).toMatchSnapshot()
-})
-
-it('clears problems with a clean document', () => {
-  mockDocument.text = `
-  zero width space \u200b\u200b\u200b
-  zero width non-joiner \u200c\u200c\u200c
-  non breaking space \u00a0\u00a0\u00a0
-  left double quotation mark \u201c\u201c\u201c
-  right double quotation mark \u201d\u201d\u201d
-  `
-  activate(context)
-  mockSetDiagnostics.mockClear()
-
-  mockDocument.text = `
-  zero width space
-  zero width non-joiner
-  non breaking space
-  left double quotation mark
-  right double quotation mark
-  `
-  activate(context)
-
-  expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
-})
-
-it('clears and then disposes diagnostics when extension is disposed', () => {
-  dispose()
-
-  const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0];
-  const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0];
-  expect(clearCallOrder).toBeLessThan(disposeCallOrder);
+    const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0];
+    const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0];
+    expect(clearCallOrder).toBeLessThan(disposeCallOrder);
+  })
 })

--- a/extension.test.js
+++ b/extension.test.js
@@ -54,6 +54,7 @@ jest.mock(
       workspace: {
         onDidChangeTextDocument: jest.fn(() => mockDisposable),
         onDidCloseTextDocument: jest.fn(() => mockDisposable),
+        onDidChangeConfiguration: jest.fn(() => mockDisposable),
         getConfiguration: jest.fn(key => {
           const packageData = require('./package.json')
           const characters =
@@ -252,28 +253,30 @@ describe('lifecycle', () => {
     activate(context)
 
     expect(mockVscode.window.onDidChangeActiveTextEditor.mock.calls).toMatchSnapshot()
-    expect(mockVscode.window.onDidChangeActiveTextEditor.mock.calls[0][0].toString()).toMatchSnapshot()
   })
 
   it('registers with window.onDidChangeTextEditorSelection', () => {
     activate(context)
 
     expect(mockVscode.window.onDidChangeTextEditorSelection.mock.calls).toMatchSnapshot()
-    expect(mockVscode.window.onDidChangeTextEditorSelection.mock.calls[0][0].toString()).toMatchSnapshot()
   })
 
   it('registers with workspace.onDidChangeTextDocument', () => {
     activate(context)
 
     expect(mockVscode.workspace.onDidChangeTextDocument.mock.calls).toMatchSnapshot()
-    expect(mockVscode.workspace.onDidChangeTextDocument.mock.calls[0][0].toString()).toMatchSnapshot()
   })
 
   it('registers with workspace.onDidCloseTextDocument', () => {
     activate(context)
 
     expect(mockVscode.workspace.onDidCloseTextDocument.mock.calls).toMatchSnapshot()
-    expect(mockVscode.workspace.onDidCloseTextDocument.mock.calls[0][0].toString()).toMatchSnapshot()
+  })
+
+  it('registers with workspace.onDidChangeConfiguration', () => {
+    activate(context)
+
+    expect(mockVscode.workspace.onDidChangeConfiguration.mock.calls).toMatchSnapshot()
   })
 
   it('clears and then disposes diagnostics when extension is disposed', () => {
@@ -284,6 +287,6 @@ describe('lifecycle', () => {
     const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0]
     const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0]
     expect(clearCallOrder).toBeLessThan(disposeCallOrder)
-    expect(mockDisposable.dispose.mock.calls.length).toBe(4)
+    expect(mockDisposable.dispose.mock.calls.length).toBe(5)
   })
 })

--- a/extension.test.js
+++ b/extension.test.js
@@ -118,7 +118,7 @@ jest.mock(
 )
 
 const mockVscode = require('vscode')
-const { activate, dispose } = require('./extension')
+const { activate, deactivate } = require('./extension')
 const context = {
   asAbsolutePath: arg => arg,
 }
@@ -128,7 +128,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  dispose()
+  deactivate()
 })
 
 describe('updateDecorations', () => {
@@ -366,13 +366,13 @@ describe('lifecycle event handling', () => {
   })
 })
 
-describe('dispose', () => {
+describe('deactivate', () => {
   beforeEach(() => {
     activate(context)
   })
 
   it('clears and then disposes diagnostics', () => {
-    dispose()
+    deactivate()
 
     const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0]
     const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0]
@@ -380,13 +380,13 @@ describe('dispose', () => {
   })
 
   it('disposes event handlers', () => {
-    dispose()
+    deactivate()
     
     expect(mockDisposable.dispose.mock.calls.length).toBe(5)
   })
 
   it('disposes decorationTypes', () => {
-    dispose()
+    deactivate()
     
     expect(mockDecorationType.dispose.mock.calls.length).toBe(mockVscode.window.createTextEditorDecorationType.mock.calls.length)
   })

--- a/extension.test.js
+++ b/extension.test.js
@@ -104,6 +104,10 @@ beforeEach(() => {
   jest.clearAllMocks()
 })
 
+afterEach(() => {
+  dispose()
+})
+
 describe('updateDecorations', () => {
   it('shows zero width space', () => {
     mockDocument.text = 'zero width space \u200b'

--- a/extension.test.js
+++ b/extension.test.js
@@ -305,20 +305,6 @@ describe('lifecycle registration', () => {
 
     expect(mockVscode.workspace.onDidChangeConfiguration.mock.calls).toMatchSnapshot()
   })
-
-  it('clears and then disposes diagnostics when extension is disposed', () => {
-    const packageData = require('./package.json')
-
-    activate(context)
-
-    dispose()
-
-    const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0]
-    const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0]
-    expect(clearCallOrder).toBeLessThan(disposeCallOrder)
-    expect(mockDisposable.dispose.mock.calls.length).toBe(5)
-    expect(mockDecorationType.dispose.mock.calls.length).toBe(mockVscode.window.createTextEditorDecorationType.mock.calls.length)
-  })
 })
 
 describe('lifecycle event handling', () => {
@@ -377,5 +363,31 @@ describe('lifecycle event handling', () => {
       expect(editor.setDecorations.mock.calls).toMatchSnapshot()
     })
     expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+})
+
+describe('dispose', () => {
+  beforeEach(() => {
+    activate(context)
+  })
+
+  it('clears and then disposes diagnostics', () => {
+    dispose()
+
+    const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0]
+    const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0]
+    expect(clearCallOrder).toBeLessThan(disposeCallOrder)
+  })
+
+  it('disposes event handlers', () => {
+    dispose()
+    
+    expect(mockDisposable.dispose.mock.calls.length).toBe(5)
+  })
+
+  it('disposes decorationTypes', () => {
+    dispose()
+    
+    expect(mockDecorationType.dispose.mock.calls.length).toBe(mockVscode.window.createTextEditorDecorationType.mock.calls.length)
   })
 })

--- a/extension.test.js
+++ b/extension.test.js
@@ -9,6 +9,10 @@ let mockDocument = {
   },
 }
 
+let mockDisposable = {
+  dispose: jest.fn()
+}
+
 const mockSetDecorations = jest.fn()
 const mockSetDiagnostics = jest.fn()
 const mockClearDiagnostics = jest.fn()
@@ -39,8 +43,8 @@ jest.mock(
   () => {
     return {
       window: {
-        onDidChangeActiveTextEditor: jest.fn(),
-        onDidChangeTextEditorSelection: jest.fn(),
+        onDidChangeActiveTextEditor: jest.fn(() => mockDisposable),
+        onDidChangeTextEditorSelection: jest.fn(() => mockDisposable),
         createTextEditorDecorationType: jest.fn(arg => arg),
         activeTextEditor: {
           document: mockDocument,
@@ -48,8 +52,8 @@ jest.mock(
         },
       },
       workspace: {
-        onDidChangeTextDocument: jest.fn(),
-        onDidCloseTextDocument: jest.fn(),
+        onDidChangeTextDocument: jest.fn(() => mockDisposable),
+        onDidCloseTextDocument: jest.fn(() => mockDisposable),
         getConfiguration: jest.fn(key => {
           const packageData = require('./package.json')
           const characters =
@@ -273,10 +277,13 @@ describe('lifecycle', () => {
   })
 
   it('clears and then disposes diagnostics when extension is disposed', () => {
+    activate(context)
+
     dispose()
 
     const clearCallOrder = mockClearDiagnostics.mock.invocationCallOrder[0]
     const disposeCallOrder = mockDisposeDiagnostics.mock.invocationCallOrder[0]
     expect(clearCallOrder).toBeLessThan(disposeCallOrder)
+    expect(mockDisposable.dispose.mock.calls.length).toBe(4)
   })
 })


### PR DESCRIPTION
## Description
This PR introduces the following changes:
1) It listens for settings changes, and triggers a reload of the gremlins configuration if it detects any.
2) It adds disposing of Disposable resources during deactivation.
3) Loaded configuration is moved from function scope to module-wide scope so that it can be accessed during extension deactivation.

Fixes #56 

## Motivation and Context
The current implementation does not update when configuration settings are changed.  Any changes require a reload of VSCode before they take effect.  This change updates the extension to listen for settings changes and then resets its in-memory configuration.

Additionally, during testing, it was discovered that several Disposable items were not being disposed of.  This normally doesn't cause any issues, as the extension is usually only deactivated when VSCode is closed.  When working with setting changes though, this runs into issues with the decorations - recreating decorations without disposing of the old ones causes the decoration changes to not actually show up (e.g. changing the gremlin icon size).

## How Has This Been Tested?
This has been tested via unit tests and manual testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
