### PR TITLE
Remove Unnecessary Calls to updateDecorations 

### DIFF
--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -90,117 +90,7 @@ Array [
 exports[`lifecycle event handling processes new file on window.onDidChangeActiveTextEditor 2`] = `
 Array [
   Array [
-    undefined,
-    Array [
-      Object {
-        "message": "1 zero width space (unicode U+200b) here",
-        "range": Object {
-          "left": Object {
-            "char": 17,
-            "line": 0,
-          },
-          "right": Object {
-            "char": 18,
-            "line": 0,
-          },
-        },
-        "severity": "DiagnosticSeverity.Error",
-        "source": "Gremlins tracker",
-      },
-    ],
-  ],
-]
-`;
-
-exports[`lifecycle event handling processes new file on window.onDidChangeTextEditorSelection 1`] = `
-Array [
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [
-      Object {
-        "hoverMessage": "1 zero width space (unicode U+200b) here",
-        "range": Object {
-          "left": Object {
-            "char": 17,
-            "line": 0,
-          },
-          "right": Object {
-            "char": 18,
-            "line": 0,
-          },
-        },
-      },
-    ],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-  Array [
-    Object {
-      "dispose": [MockFunction],
-    },
-    Array [],
-  ],
-]
-`;
-
-exports[`lifecycle event handling processes new file on window.onDidChangeTextEditorSelection 2`] = `
-Array [
-  Array [
-    undefined,
+    "document4",
     Array [
       Object {
         "message": "1 zero width space (unicode U+200b) here",
@@ -310,7 +200,7 @@ Array [
 exports[`lifecycle event handling processes new file on workspace.onDidChangeTextDocument 2`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [
       Object {
         "message": "1 zero width space (unicode U+200b) here",
@@ -1797,27 +1687,17 @@ Array [
 exports[`lifecycle event handling processes visible text editors on workspace.onDidChangeConfiguration 3`] = `
 Array [
   Array [
-    undefined,
+    "document2",
     Array [],
   ],
   Array [
-    undefined,
+    "document3",
     Array [],
   ],
 ]
 `;
 
 exports[`lifecycle registration registers with window.onDidChangeActiveTextEditor 1`] = `
-Array [
-  Array [
-    [Function],
-    null,
-    undefined,
-  ],
-]
-`;
-
-exports[`lifecycle registration registers with window.onDidChangeTextEditorSelection 1`] = `
 Array [
   Array [
     [Function],
@@ -1931,7 +1811,7 @@ Array [
 exports[`updateDecorations clears problems with a clean document 1`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [],
   ],
 ]
@@ -2025,7 +1905,7 @@ Array [
 exports[`updateDecorations shows left double quotation mark in problems 1`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [
       Object {
         "message": "1 left double quotation mark (unicode U+201c) here",
@@ -2191,7 +2071,7 @@ Array [
 exports[`updateDecorations shows multiple characters on multiple lines in problems 1`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [
       Object {
         "message": "3 zero width spaces (unicode U+200b) here",
@@ -2361,7 +2241,7 @@ Array [
 exports[`updateDecorations shows non breaking space in problems 1`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [
       Object {
         "message": "1 non breaking space (unicode U+00a0) here",
@@ -2471,7 +2351,7 @@ Array [
 exports[`updateDecorations shows object replacement character in problems 1`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [
       Object {
         "message": "1 object replacement character (unicode U+fffc) here",
@@ -2581,7 +2461,7 @@ Array [
 exports[`updateDecorations shows right double quotation mark in problems 1`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [
       Object {
         "message": "1 right double quotation mark (unicode U+201d) here",
@@ -2691,7 +2571,7 @@ Array [
 exports[`updateDecorations shows zero width non-joiner in problems 1`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [
       Object {
         "message": "1 zero width non-joiner (unicode U+200c) here",
@@ -2801,7 +2681,7 @@ Array [
 exports[`updateDecorations shows zero width space in problems 1`] = `
 Array [
   Array [
-    undefined,
+    "document1",
     Array [
       Object {
         "message": "1 zero width space (unicode U+200b) here",

--- a/extension.js
+++ b/extension.js
@@ -153,7 +153,7 @@ function charFromHex(hexCodePoint) {
  * @param {RegExp} regexpWithAllChars 
  * @param {vscode.DiagnosticCollection} diagnosticCollection
  */
-function updateDecorations(activeTextEditor, gremlins, regexpWithAllChars, diagnosticCollection) {
+function checkForGremlins(activeTextEditor, gremlins, regexpWithAllChars, diagnosticCollection) {
   if (!activeTextEditor) {
     return
   }
@@ -222,7 +222,7 @@ function updateDecorations(activeTextEditor, gremlins, regexpWithAllChars, diagn
 function activate(context) {
   configuration = loadConfiguration(context)
 
-  const doUpdateDecorations = editor => updateDecorations(
+  const doCheckForGremlins = editor => checkForGremlins(
     editor,
     configuration.gremlins,
     configuration.regexpWithAllChars,
@@ -236,7 +236,7 @@ function activate(context) {
           disposeDecorationTypes(configuration.gremlins)
 
           configuration = loadConfiguration(context)
-          vscode.window.visibleTextEditors.forEach(editor => doUpdateDecorations(editor))
+          vscode.window.visibleTextEditors.forEach(editor => doCheckForGremlins(editor))
         }
       },
       null,
@@ -248,7 +248,7 @@ function activate(context) {
     vscode.window.onDidChangeActiveTextEditor(
       editor => {
         if (!processedDocuments[editor.document.uri]) {
-          doUpdateDecorations(editor)
+          doCheckForGremlins(editor)
         }
       },
       null,
@@ -258,7 +258,7 @@ function activate(context) {
 
   eventListeners.push(
     vscode.workspace.onDidChangeTextDocument(
-      event => doUpdateDecorations(vscode.window.activeTextEditor),
+      event => doCheckForGremlins(vscode.window.activeTextEditor),
       null,
       context.subscriptions,
     )
@@ -275,7 +275,7 @@ function activate(context) {
     )
   )
 
-  doUpdateDecorations(vscode.window.activeTextEditor)
+  doCheckForGremlins(vscode.window.activeTextEditor)
 }
 exports.activate = activate
 

--- a/extension.js
+++ b/extension.js
@@ -257,14 +257,6 @@ function activate(context) {
   )
 
   eventListeners.push(
-    vscode.window.onDidChangeTextEditorSelection(
-      event => doUpdateDecorations(event.textEditor),
-      null,
-      context.subscriptions,
-    )
-  )
-
-  eventListeners.push(
     vscode.workspace.onDidChangeTextDocument(
       event => doUpdateDecorations(vscode.window.activeTextEditor),
       null,

--- a/extension.js
+++ b/extension.js
@@ -18,6 +18,8 @@ const GREMLINS_SEVERITIES = {
 
 const eventListeners = []
 
+const processedDocuments = {}
+
 let configuration = null
 
 let diagnosticCollection = null
@@ -213,6 +215,8 @@ function updateDecorations(activeTextEditor, gremlins, regexpWithAllChars, diagn
   if (diagnosticCollection) {
     diagnosticCollection.set(activeTextEditor.document.uri, diagnostics)
   }
+
+  processedDocuments[activeTextEditor.document.uri] = true
 }
 
 function activate(context) {
@@ -242,7 +246,11 @@ function activate(context) {
 
   eventListeners.push(
     vscode.window.onDidChangeActiveTextEditor(
-      editor => doUpdateDecorations(editor),
+      editor => {
+        if (!processedDocuments[editor.document.uri]) {
+          doUpdateDecorations(editor)
+        }
+      },
       null,
       context.subscriptions,
     )
@@ -266,7 +274,10 @@ function activate(context) {
 
   eventListeners.push(
     vscode.workspace.onDidCloseTextDocument(
-      textDocument => diagnosticCollection && diagnosticCollection.delete(textDocument.uri),
+      textDocument => {
+        diagnosticCollection && diagnosticCollection.delete(textDocument.uri)
+        delete processedDocuments[textDocument.uri]
+      },
       null,
       context.subscriptions
     )

--- a/extension.test.js
+++ b/extension.test.js
@@ -334,6 +334,13 @@ describe('lifecycle event handling', () => {
     expect(mockSetDecorations.mock.calls).toMatchSnapshot()
     expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
   })
+  
+  it('does NOT process already-processed file on window.onDidChangeActiveTextEditor', () => {
+    eventHandlers.window.onDidChangeActiveTextEditor(mockVscode.window.activeTextEditor)
+    
+    expect(mockSetDecorations.mock.calls.length).toBe(0)
+    expect(mockSetDiagnostics.mock.calls.length).toBe(0)
+  })
 
   it('processes new file on workspace.onDidChangeTextDocument', () => {
     eventHandlers.workspace.onDidChangeTextDocument()


### PR DESCRIPTION
## Description
Fixes #7 
This PR removes extra calls to updateDecorations, specifically:

1. During onDidChangeActiveTextEditor, when the newly active document has already been processed
2. **All** calls to `onDidChangeTextEditorSelection` (when user selects text, but makes no changes).

## Motivation and Context
This improves reduces the overhead caused by the extension by removing a lot of extra parses of documents.

## How Has This Been Tested?
I've added a series of new Unit Tests, and also tested these changes via the VSCode debugger.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
