### PR TITLE
Add "paragraph separator" to default characters

### DIFF
--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -2335,7 +2335,21 @@ Array [
     Object {
       "dispose": [MockFunction],
     },
-    Array [],
+    Array [
+      Object {
+        "hoverMessage": "3 paragraph separators (unicode U+2029) here",
+        "range": Object {
+          "left": Object {
+            "char": 20,
+            "line": 3,
+          },
+          "right": Object {
+            "char": 23,
+            "line": 3,
+          },
+        },
+      },
+    ],
   ],
   Array [
     Object {
@@ -2353,11 +2367,11 @@ Array [
         "range": Object {
           "left": Object {
             "char": 19,
-            "line": 3,
+            "line": 4,
           },
           "right": Object {
             "char": 22,
-            "line": 3,
+            "line": 4,
           },
         },
       },
@@ -2419,11 +2433,11 @@ Array [
         "range": Object {
           "left": Object {
             "char": 27,
-            "line": 4,
+            "line": 5,
           },
           "right": Object {
             "char": 30,
-            "line": 4,
+            "line": 5,
           },
         },
       },
@@ -2439,11 +2453,11 @@ Array [
         "range": Object {
           "left": Object {
             "char": 28,
-            "line": 5,
+            "line": 6,
           },
           "right": Object {
             "char": 31,
-            "line": 5,
+            "line": 6,
           },
         },
       },
@@ -2512,15 +2526,30 @@ Array [
         "source": "Gremlins tracker",
       },
       Object {
+        "message": "3 paragraph separators (unicode U+2029) here",
+        "range": Object {
+          "left": Object {
+            "char": 20,
+            "line": 3,
+          },
+          "right": Object {
+            "char": 23,
+            "line": 3,
+          },
+        },
+        "severity": "DiagnosticSeverity.Error",
+        "source": "Gremlins tracker",
+      },
+      Object {
         "message": "3 non breaking spaces (unicode U+00a0) here",
         "range": Object {
           "left": Object {
             "char": 19,
-            "line": 3,
+            "line": 4,
           },
           "right": Object {
             "char": 22,
-            "line": 3,
+            "line": 4,
           },
         },
         "severity": "DiagnosticSeverity.Information",
@@ -2531,11 +2560,11 @@ Array [
         "range": Object {
           "left": Object {
             "char": 27,
-            "line": 4,
+            "line": 5,
           },
           "right": Object {
             "char": 30,
-            "line": 4,
+            "line": 5,
           },
         },
         "severity": "DiagnosticSeverity.Warning",
@@ -2546,11 +2575,11 @@ Array [
         "range": Object {
           "left": Object {
             "char": 28,
-            "line": 5,
+            "line": 6,
           },
           "right": Object {
             "char": 31,
-            "line": 5,
+            "line": 6,
           },
         },
         "severity": "DiagnosticSeverity.Warning",
@@ -2782,6 +2811,122 @@ Array [
           },
           "right": Object {
             "char": 30,
+            "line": 0,
+          },
+        },
+        "severity": "DiagnosticSeverity.Error",
+        "source": "Gremlins tracker",
+      },
+    ],
+  ],
+]
+`;
+
+exports[`updateDecorations shows paragraph separator 1`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [
+      Object {
+        "hoverMessage": "1 paragraph separator (unicode U+2029) here",
+        "range": Object {
+          "left": Object {
+            "char": 20,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 21,
+            "line": 0,
+          },
+        },
+      },
+    ],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+]
+`;
+
+exports[`updateDecorations shows paragraph separator in problems 1`] = `
+Array [
+  Array [
+    undefined,
+    Array [
+      Object {
+        "message": "1 paragraph separator (unicode U+2029) here",
+        "range": Object {
+          "left": Object {
+            "char": 20,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 21,
             "line": 0,
           },
         },

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -20,6 +20,12 @@ Array [
     Object {
       "dispose": [MockFunction],
     },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
     Array [
       Object {
         "hoverMessage": "1 zero width space (unicode U+200b) here",
@@ -114,6 +120,12 @@ Array [
 
 exports[`lifecycle event handling processes new file on window.onDidChangeTextEditorSelection 1`] = `
 Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
   Array [
     Object {
       "dispose": [MockFunction],
@@ -240,6 +252,12 @@ Array [
     Object {
       "dispose": [MockFunction],
     },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
     Array [
       Object {
         "hoverMessage": "1 zero width space (unicode U+200b) here",
@@ -349,8 +367,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -415,8 +438,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -481,8 +509,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -547,8 +580,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -613,8 +651,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -679,8 +722,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -745,8 +793,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -811,8 +864,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -877,8 +935,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -943,8 +1006,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1009,8 +1077,84 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1080,8 +1224,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1146,8 +1295,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1212,8 +1366,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1278,8 +1437,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1344,8 +1508,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1410,8 +1579,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1476,8 +1650,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1542,8 +1721,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1608,8 +1792,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1674,8 +1863,13 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1740,8 +1934,84 @@ Array [
           Array [],
           Array [],
           Array [],
+          Array [],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction] {
+        "calls": Array [
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,
@@ -1925,6 +2195,12 @@ Array [
     },
     Array [],
   ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
 ]
 `;
 
@@ -1939,6 +2215,12 @@ Array [
 
 exports[`updateDecorations shows left double quotation mark 1`] = `
 Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
   Array [
     Object {
       "dispose": [MockFunction],
@@ -2049,6 +2331,12 @@ Array [
 
 exports[`updateDecorations shows multiple characters on multiple lines 1`] = `
 Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
   Array [
     Object {
       "dispose": [MockFunction],
@@ -2285,6 +2573,12 @@ Array [
     Object {
       "dispose": [MockFunction],
     },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
     Array [
       Object {
         "hoverMessage": "1 non breaking space (unicode U+00a0) here",
@@ -2449,6 +2743,12 @@ Array [
     Object {
       "dispose": [MockFunction],
     },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
     Array [
       Object {
         "hoverMessage": "1 object replacement character (unicode U+fffc) here",
@@ -2495,6 +2795,12 @@ Array [
 
 exports[`updateDecorations shows right double quotation mark 1`] = `
 Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
   Array [
     Object {
       "dispose": [MockFunction],
@@ -2627,6 +2933,12 @@ Array [
     Object {
       "dispose": [MockFunction],
     },
+    Array [],
+  ],
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
     Array [
       Object {
         "hoverMessage": "1 zero width non-joiner (unicode U+200c) here",
@@ -2715,6 +3027,12 @@ Array [
 
 exports[`updateDecorations shows zero width space 1`] = `
 Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
   Array [
     Object {
       "dispose": [MockFunction],

--- a/extension.test.js
+++ b/extension.test.js
@@ -156,6 +156,18 @@ describe('updateDecorations', () => {
     expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
   })
 
+  it('shows paragraph separator', () => {
+    mockDocument.text = 'paragraph separator \u2029'
+    activate(context)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+  })
+
+  it('shows paragraph separator in problems', () => {
+    mockDocument.text = 'paragraph separator \u2029'
+    activate(context)
+    expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+  })
+
   it('shows non breaking space', () => {
     mockDocument.text = 'non breaking space \u00a0'
     activate(context)
@@ -208,6 +220,7 @@ describe('updateDecorations', () => {
     mockDocument.text = outdent`
     zero width space \u200b\u200b\u200b
     zero width non-joiner \u200c\u200c\u200c
+    paragraph separator \u2029\u2029\u2029
     non breaking space \u00a0\u00a0\u00a0
     left double quotation mark \u201c\u201c\u201c
     right double quotation mark \u201d\u201d\u201d
@@ -220,6 +233,7 @@ describe('updateDecorations', () => {
     mockDocument.text = outdent`
     zero width space \u200b\u200b\u200b
     zero width non-joiner \u200c\u200c\u200c
+    paragraph separator \u2029\u2029\u2029
     non breaking space \u00a0\u00a0\u00a0
     left double quotation mark \u201c\u201c\u201c
     right double quotation mark \u201d\u201d\u201d
@@ -232,6 +246,7 @@ describe('updateDecorations', () => {
     mockDocument.text = outdent`
     zero width space \u200b\u200b\u200b
     zero width non-joiner \u200c\u200c\u200c
+    paragraph separator \u2029\u2029\u2029
     non breaking space \u00a0\u00a0\u00a0
     left double quotation mark \u201c\u201c\u201c
     right double quotation mark \u201d\u201d\u201d
@@ -242,6 +257,7 @@ describe('updateDecorations', () => {
     mockDocument.text = outdent`
     zero width space
     zero width non-joiner
+    paragraph separator
     non breaking space
     left double quotation mark
     right double quotation mark
@@ -255,6 +271,7 @@ describe('updateDecorations', () => {
     mockDocument.text = outdent`
     zero width space \u200b\u200b\u200b
     zero width non-joiner \u200c\u200c\u200c
+    paragraph separator \u2029\u2029\u2029
     non breaking space \u00a0\u00a0\u00a0
     left double quotation mark \u201c\u201c\u201c
     right double quotation mark \u201d\u201d\u201d
@@ -265,6 +282,7 @@ describe('updateDecorations', () => {
     mockDocument.text = outdent`
     zero width space
     zero width non-joiner
+    paragraph separator
     non breaking space
     left double quotation mark
     right double quotation mark

--- a/package.json
+++ b/package.json
@@ -109,6 +109,11 @@
               "description": "right double quotation mark",
               "level": "warning"
             },
+            "2029": {
+              "zeroWidth": true,
+              "description": "paragraph separator",
+              "level": "error"
+            },
             "202c": {
               "zeroWidth": true,
               "description": "pop directional formatting",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the [Paragraph Separator (U+2029)](https://www.compart.com/en/unicode/U+2029) to the list of default characters.

## Motivation and Context
This is a hard-to-find zero-width character which can be added through copying paragraph text from graphics editors like Photoshop or Sketch (got it from a PSD converted to a Sketch file, not sure which the original source of the character was).

Generally, one could add all zero-width characters from the Unicode [General Punctuation](https://www.compart.com/en/unicode/block/U+2000) block (i.e. all characters on the linked page which are represented by their abbreviation with a dotted border).

## How Has This Been Tested?
- Added it to my local list of `gremlins.characters`, it correctly reports occurences.
- Added jest test cases

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
  
  Note that I have updated existing snapshopts (before adding new tests) and cannot verify that the new snapshots are correct. No way for me to interpret them correctly.

- [x] All new and existing tests passed.
