### PR TITLE
Add hideGutterIcon prop to character options

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -95,8 +95,8 @@ function gremlinsFromConfig(gremlinsConfiguration, context) {
   const gremlins = {}
   for (const [hexCodePoint, config] of Object.entries(gremlinsCharacters)) {
     let decorationType = {
-      light: lightIcon,
-      dark: darkIcon,
+      light: config.hideGutterIcon ? {} : lightIcon,
+      dark: config.hideGutterIcon ? {} : darkIcon,
       overviewRulerColor: config.overviewRulerColor || gremlinsDefaultColor,
       overviewRulerLane: vscode.OverviewRulerLane.Right,
     }
@@ -147,10 +147,10 @@ function charFromHex(hexCodePoint) {
 }
 
 /**
- * 
- * @param {vscode.TextEditor} activeTextEditor 
- * @param {*} gremlins 
- * @param {RegExp} regexpWithAllChars 
+ *
+ * @param {vscode.TextEditor} activeTextEditor
+ * @param {*} gremlins
+ * @param {RegExp} regexpWithAllChars
  * @param {vscode.DiagnosticCollection} diagnosticCollection
  */
 function checkForGremlins(activeTextEditor, gremlins, regexpWithAllChars, diagnosticCollection) {
@@ -191,7 +191,7 @@ function checkForGremlins(activeTextEditor, gremlins, regexpWithAllChars, diagno
       }
 
       decorationOption[matchedCharacter].push(decoration)
-      
+
       if (diagnosticCollection) {
         const severity = GREMLINS_SEVERITIES[gremlin.level]
         const diagnostic = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a config option to allow users to hide the gutter icon for a particular character

## Description

The user can now now hide the gremlins gutter icon for a character by doing  this:

```json
{
  "gremlins.characters": {
    "2013": {
      "description": "en dash",
      "hideGutterIcon": true,
      "level": "info"
    }
  }
}
```

## Motivation and Context

Certain characters, such as the _en dash_, are perfectly valid (e.g. in text content when showing a numeric range like 1–5). The gutter icon can be distracting, and there isn't currently a way to remove a character from the list of "gremlins." The simplest path I've found for "hiding" all the ways that the gremlins extension flags the character is to set "transparent" for the `info` severity level and then set the character's options to:

```json
{
  "description": "en dash",
  "overviewRulerColor": "transparent",
  "level": "info"
}
```

But that still leaves the icon showing up in the gutter. 

To remove the icon, I just had the script look for `"hideGutterIcon": true` and pass in an empty object instead of the light/dark icon objects.

## How Has This Been Tested?

I tested this visually/manually, but haven't added any tests to `jest` because I wasn't sure how to do that.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
