### PR TITLE
Repaint decorations when switching back to tab

### DIFF
--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -167,6 +167,31 @@ Array [
 ]
 `;
 
+exports[`lifecycle event handling re-paints gremlins for already-processed file on window.onDidChangeActiveTextEditor 1`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [
+      Object {
+        "hoverMessage": "1 zero width space (unicode U+200b) here",
+        "range": Object {
+          "left": Object {
+            "char": 17,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 18,
+            "line": 0,
+          },
+        },
+      },
+    ],
+  ],
+]
+`;
+
 exports[`lifecycle registration registers with window.onDidChangeActiveTextEditor 1`] = `
 Array [
   Array [

--- a/extension.js
+++ b/extension.js
@@ -18,7 +18,7 @@ const GREMLINS_SEVERITIES = {
 
 const eventListeners = []
 
-const decorationTypes = {}
+let decorationTypes = {}
 
 const processedDocuments = {}
 
@@ -42,8 +42,8 @@ function configureDiagnosticsCollection(showDiagnostics) {
 function disposeDecorationTypes() {
   Object.entries(decorationTypes).forEach(([key, decorationType]) => {
     decorationType.dispose()
-    delete decorationTypes[key]
   })
+  decorationTypes = {}
 }
 
 function loadConfiguration(context) {
@@ -223,15 +223,13 @@ function checkForGremlins(
 
   const decorations = groupDecorationsByType(gremlins, decorationOption)
 
-  for (const { decorationType, options } of Object.values(decorations)) {
-    activeTextEditor.setDecorations(decorationType, options)
-  }
+  drawDecorations(activeTextEditor, decorations)
 
   if (diagnosticCollection) {
     diagnosticCollection.set(activeTextEditor.document.uri, diagnostics)
   }
 
-  processedDocuments[activeTextEditor.document.uri] = true
+  processedDocuments[activeTextEditor.document.uri] = { decorations }
 }
 
 function groupDecorationsByType(gremlins, decorationOption) {
@@ -251,6 +249,12 @@ function groupDecorationsByType(gremlins, decorationOption) {
     }
     return obj
   }, {})
+}
+
+function drawDecorations(activeTextEditor, decorations) {
+  for (const { decorationType, options } of Object.values(decorations)) {
+    activeTextEditor.setDecorations(decorationType, options)
+  }
 }
 
 function activate(context) {
@@ -284,8 +288,13 @@ function activate(context) {
   eventListeners.push(
     vscode.window.onDidChangeActiveTextEditor(
       (editor) => {
-        if (editor && !processedDocuments[editor.document.uri]) {
-          doCheckForGremlins(editor)
+        if (editor) {
+          const processedDocument = processedDocuments[editor.document.uri]
+          if (!processedDocument) {
+            doCheckForGremlins(editor)
+          } else {
+            drawDecorations(editor, processedDocument.decorations)
+          }
         }
       },
       null,

--- a/extension.js
+++ b/extension.js
@@ -20,7 +20,7 @@ const eventListeners = []
 
 let decorationTypes = {}
 
-const processedDocuments = {}
+let processedDocuments = {}
 
 let configuration = null
 
@@ -273,6 +273,7 @@ function activate(context) {
       (event) => {
         if (event.affectsConfiguration(GREMLINS)) {
           disposeDecorationTypes()
+          processedDocuments = {}
 
           configuration = loadConfiguration(context)
           vscode.window.visibleTextEditors.forEach((editor) =>

--- a/extension.test.js
+++ b/extension.test.js
@@ -9,7 +9,7 @@ const createMockDocument = (text = '') => {
       const lines = this.text.split('\n')
       return { text: lines[index] }
     },
-    uri: 'document' + incrementingUri++
+    uri: 'document' + incrementingUri++,
   }
 }
 
@@ -77,7 +77,7 @@ jest.mock(
         onDidChangeTextDocument: jest.fn(() => mockDisposable),
         onDidCloseTextDocument: jest.fn(() => mockDisposable),
         onDidChangeConfiguration: jest.fn(() => mockDisposable),
-        getConfiguration: jest.fn(key => {
+        getConfiguration: jest.fn((key) => {
           const packageData = require('./package.json')
           const characters =
             packageData.contributes.configuration.properties[
@@ -96,7 +96,7 @@ jest.mock(
         }),
       },
       languages: {
-        createDiagnosticCollection: jest.fn(key => ({
+        createDiagnosticCollection: jest.fn((key) => ({
           set: mockSetDiagnostics,
           delete: mockDeleteDiagnostics,
           clear: mockClearDiagnostics,
@@ -123,7 +123,7 @@ jest.mock(
 const mockVscode = require('vscode')
 const { activate, deactivate } = require('./extension')
 const context = {
-  asAbsolutePath: arg => arg,
+  asAbsolutePath: (arg) => arg,
 }
 
 beforeEach(() => {
@@ -345,7 +345,7 @@ describe('lifecycle registration', () => {
 describe('lifecycle event handling', () => {
   function getEventHandlers(object) {
     return Object.keys(object)
-      .filter(key => key.startsWith('on'))
+      .filter((key) => key.startsWith('on'))
       .reduce((handlers, nextKey) => {
         handlers[nextKey] = object[nextKey].mock.calls[0][0]
         return handlers
@@ -370,14 +370,16 @@ describe('lifecycle event handling', () => {
     }
 
     eventHandlers.window.onDidChangeActiveTextEditor(newMockEditor)
-    
+
     expect(mockSetDecorations.mock.calls).toMatchSnapshot()
     expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
   })
-  
+
   it('does NOT process already-processed file on window.onDidChangeActiveTextEditor', () => {
-    eventHandlers.window.onDidChangeActiveTextEditor(mockVscode.window.activeTextEditor)
-    
+    eventHandlers.window.onDidChangeActiveTextEditor(
+      mockVscode.window.activeTextEditor,
+    )
+
     expect(mockSetDecorations.mock.calls.length).toBe(0)
     expect(mockSetDiagnostics.mock.calls.length).toBe(0)
   })
@@ -397,11 +399,11 @@ describe('lifecycle event handling', () => {
 
   it('processes visible text editors on workspace.onDidChangeConfiguration', () => {
     eventHandlers.workspace.onDidChangeConfiguration({
-      affectsConfiguration: jest.fn(arg => true),
+      affectsConfiguration: jest.fn((arg) => true),
     })
 
     expect(mockSetDecorations.mock.calls.length).toBe(0)
-    mockVscode.window.visibleTextEditors.forEach(editor => {
+    mockVscode.window.visibleTextEditors.forEach((editor) => {
       expect(editor.setDecorations.mock.calls).toMatchSnapshot()
     })
     expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
@@ -425,7 +427,7 @@ describe('deactivate', () => {
     const totalEvents = 4
 
     deactivate()
-    
+
     expect(mockDisposable.dispose.mock.calls.length).toBe(totalEvents)
   })
 

--- a/extension.test.js
+++ b/extension.test.js
@@ -380,8 +380,16 @@ describe('lifecycle event handling', () => {
       mockVscode.window.activeTextEditor,
     )
 
-    expect(mockSetDecorations.mock.calls.length).toBe(0)
     expect(mockSetDiagnostics.mock.calls.length).toBe(0)
+  })
+
+  it('re-paints gremlins for already-processed file on window.onDidChangeActiveTextEditor', () => {
+    eventHandlers.window.onDidChangeActiveTextEditor(
+      mockVscode.window.activeTextEditor,
+    )
+
+    expect(mockSetDecorations.mock.calls.length).toBe(1)
+    expect(mockSetDecorations.mock.calls).toMatchSnapshot()
   })
 
   it('processes new file on workspace.onDidChangeTextDocument', () => {


### PR DESCRIPTION
## Description
Fixes #139 
- When switching away from a document and back, decorations are re-painted.
- When changing settings, decorations for already-processed-documents are re-painted.

## Motivation and Context
Fixing broken functionality.

## How Has This Been Tested?
Manual and unit testing.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
