### PR TITLE
Add `gremlins.characters` schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,8 +155,32 @@
               "level": "error"
             }
           },
-          "items": {
-            "type": "object"
+          "additionalProperties": {
+            "type": "object",
+            "required": ["level"],
+            "properties": {
+              "zeroWidth": {
+                "type": "boolean",
+                "description": "Whether this character is a zero-width character"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of this character"
+              },
+              "level": {
+                "type": "string",
+                "description": "Severity level associated with this character",
+                "enum": ["info", "warning", "error"]
+              },
+              "hideGutterIcon" : {
+                "type": "boolean",
+                "description": "If true, hides the gutter icon for this character"
+              },
+              "overviewRulerColor": {
+                "type": "boolean",
+                "description": "Color to use in the overview ruler (defaults to dark red)"
+              }
+            }
           },
           "minItems": 1,
           "uniqueItems": true


### PR DESCRIPTION
## Description
I added a JSON schema for the `gremlins.characters` objects.  This was done by adding the schema underneath the `additionalProperties` property, which defines configuration for any arbitrary keys added to this configuration object (i.e. the hexcode key for the given gremlin being configured.  Each entry now consists of the following properties:
* `level` (enum - `error|warning|info` - **required**)
* `description` (string - _optional_)
* `zeroWidth` (boolean - _optional_)
* `hideGutterIcon` (boolean - _optional_)
* `overviewRulerColor`  (boolean - _optional_)

## Motivation and Context
This change makes it easier to configure the `gremlins.characters` setting by providing intellisense for the fields.

## How Has This Been Tested?
Manual testing by mousing over entries in `settings.json`.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9260413/95106511-9cfda980-0706-11eb-870e-bc272d3ef347.png)
![image](https://user-images.githubusercontent.com/9260413/95106916-2f05b200-0707-11eb-9528-a9445e37bc75.png)
![image](https://user-images.githubusercontent.com/9260413/95107302-b94e1600-0707-11eb-9c91-d51a3aa8edfc.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
