### PR TITLE
Add "none" level to ignore character defined in defaults

### DIFF
--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -1,5 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`configuration level setting level to none prevents decoration from being displayed 1`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [
+      Object {
+        "hoverMessage": "1 zero width space (unicode U+200b) here",
+        "range": Object {
+          "left": Object {
+            "char": 17,
+            "line": 0,
+          },
+          "right": Object {
+            "char": 18,
+            "line": 0,
+          },
+        },
+      },
+    ],
+  ],
+]
+`;
+
+exports[`configuration level setting level to none prevents decoration from being displayed 2`] = `Array []`;
+
+exports[`configuration level setting level to none prevents decoration from being displayed 3`] = `
+Array [
+  Array [
+    "document1",
+    Array [],
+  ],
+]
+`;
+
+exports[`configuration level setting level to none prevents decoration from being displayed 4`] = `
+Array [
+  Array [
+    "document1",
+    Array [],
+  ],
+  Array [
+    "document2",
+    Array [],
+  ],
+  Array [
+    "document3",
+    Array [],
+  ],
+]
+`;
+
 exports[`lifecycle event handling clears diagnostics on workspace.onDidCloseTextDocument 1`] = `undefined`;
 
 exports[`lifecycle event handling processes new file on window.onDidChangeActiveTextEditor 1`] = `

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,5 @@
 var vscode = require('vscode')
 
-const gremlinsDefaultColor = 'rgba(169, 68, 66, .75)'
-
 const GREMLINS = 'gremlins'
 
 const GREMLINS_LEVELS = {
@@ -16,6 +14,8 @@ const GREMLINS_SEVERITIES = {
   [GREMLINS_LEVELS.WARNING]: vscode.DiagnosticSeverity.Warning,
   [GREMLINS_LEVELS.ERROR]: vscode.DiagnosticSeverity.Error,
 }
+
+const gremlinsDefaultColor = 'rgba(169, 68, 66, .75)'
 
 const eventListeners = []
 
@@ -100,10 +100,12 @@ function gremlinsFromConfig(gremlinsConfiguration, context) {
 
   const gremlins = {}
   for (const [hexCodePoint, config] of Object.entries(gremlinsCharacters)) {
-    if (config.level === GREMLINS_LEVELS.NONE) {
+    const severityLevel = (config.level ? config.level.toLowerCase() : GREMLINS_LEVELS.ERROR)
+    if (severityLevel === GREMLINS_LEVELS.NONE) {
       // Ignore gremlins marked as "none"
       continue;
     }
+    
     let decorationType = {
       light: config.hideGutterIcon ? {} : lightIcon,
       dark: config.hideGutterIcon ? {} : darkIcon,
@@ -114,11 +116,9 @@ function gremlinsFromConfig(gremlinsConfiguration, context) {
     if (config.zeroWidth) {
       decorationType.borderWidth = '1px'
       decorationType.borderStyle = 'solid'
-      decorationType.borderColor =
-        gremlinsLevels[config.level] || gremlinsDefaultColor
+      decorationType.borderColor = gremlinsLevels[severityLevel]
     } else {
-      decorationType.backgroundColor =
-        gremlinsLevels[config.level] || gremlinsDefaultColor
+      decorationType.backgroundColor = gremlinsLevels[severityLevel]
     }
 
     let hexCodePointsRange = hexCodePoint.match(hexCodePointsRangeRegex)

--- a/extension.js
+++ b/extension.js
@@ -5,6 +5,7 @@ const gremlinsDefaultColor = 'rgba(169, 68, 66, .75)'
 const GREMLINS = 'gremlins'
 
 const GREMLINS_LEVELS = {
+  NONE: 'none',
   INFO: 'info',
   WARNING: 'warning',
   ERROR: 'error',
@@ -99,6 +100,10 @@ function gremlinsFromConfig(gremlinsConfiguration, context) {
 
   const gremlins = {}
   for (const [hexCodePoint, config] of Object.entries(gremlinsCharacters)) {
+    if (config.level === GREMLINS_LEVELS.NONE) {
+      // Ignore gremlins marked as "none"
+      continue;
+    }
     let decorationType = {
       light: config.hideGutterIcon ? {} : lightIcon,
       dark: config.hideGutterIcon ? {} : darkIcon,

--- a/package.json
+++ b/package.json
@@ -170,7 +170,13 @@
               "level": {
                 "type": "string",
                 "description": "Severity level associated with this character",
-                "enum": ["info", "warning", "error"]
+                "enum": ["none", "info", "warning", "error"],
+                "enumDescriptions": [
+                  "Do not mark - used to disable configuration from other scopes (e.g. defaults)",
+                  "Highlight using **info** color and log as **info** in problem pane",
+                  "Highlight using **warning** color and log as **warning** in problem pane",
+                  "Highlight using **error** color and log as **error** in problem pane"
+                ]
               },
               "hideGutterIcon" : {
                 "type": "boolean",


### PR DESCRIPTION
## Description
I added a "none" level to the severities to allow a character to be marked as "not an issue".  This allows users to mark characters as acceptable that are defined otherwise in the defaults or another higher-scoped configuration (e.g. overriding characters from user settings in workspace settings).  They will not be decorated, highlighted, underlined, show up in the overview rule, or in the problem page.

I also updated the JSON schema to document the new level.

A separate issue should be opened to cover a general documentation overhaul that adds the schema to the README so that it is more visibile.

## Motivation and Context
Currently, default characters are always considered "gremlins", and the only available workaround is to set the level to "info", change the "info" color (breaks legit "info" characters) and hide the decoration.

Fixes #122
Fixes #144 

## How Has This Been Tested?
I did manual testing and wrote new units tests.

## Screenshots (if appropriate):
### Before
![image](https://user-images.githubusercontent.com/9260413/95534307-73b57580-09b3-11eb-8ae1-5e8082d47e1c.png)

### After
![image](https://user-images.githubusercontent.com/9260413/95534318-82039180-09b3-11eb-9876-0a591264db8c.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
