### PR TITLE
Make `gremlins.characters` language-overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ As an example, the following snippet adds the "U+000C" (form feed) character and
     "000c" : {
       "zeroWidth": true,
       "description": "FORM FEED (FF)",
-      "overviewRulerColor": "rgba(255,127,80,1)",
+      "level": "error",
     },
     // Ignore the non-breaking space character for markdown files
     "00a0": {

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can configure the list of additional characters and how they are shown under
 
 As an example, the following snippet adds the "U+000C" FORM FEED character:
 
-```
+```jsonc
 "gremlins.characters": {
   "000c" : {
     "zeroWidth": true,
@@ -52,7 +52,7 @@ You can override the characters for a specific language by configuring them in t
 
 As an example, the following snippet adds the "U+000C" (form feed) character and disables the "U+00A0" (non-breaking space) character for markdown files:
 
-```
+```jsonc
 "[markdown]": {
   "gremlins.characters": {
     // Add the form feed character for markdown files
@@ -78,7 +78,7 @@ Still under user settings key `gremlins.characters`, you can add the `hideGutter
 
 For example, this removes the gremlin icon in the gutter for non breakable spaces:
 
-```
+```jsonc
 "gremlins.characters": {
   "00a0" : {
     "hideGutterIcon": true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can also use the [“Unicode code point of current character” extension](h
 
 ## Adding new gremlins characters
 
-You can configure the list of additionnal characters and how they are shown under user settings key `gremlins.characters`.
+You can configure the list of additional characters and how they are shown under user settings key `gremlins.characters`.
 
 As an example, the following snippet adds the "U+000C" FORM FEED character:
 
@@ -43,6 +43,32 @@ As an example, the following snippet adds the "U+000C" FORM FEED character:
 Please help enhance the extension by suggesting new default characters, through Pull Requests or Issues.
 
 You can find all characters in [Unicode Table](https://unicode-table.com/en/).
+
+## Language-specific gremlins characters
+
+You can override the characters for a specific language by configuring them in the `gremlins.characters` property of the language-specific settings key (e.g. `[markdown]` for Markdown files).
+
+> More information about language specific settings can be found in the [Language specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_language-specific-editor-settings) VSCode documentation page.
+
+As an example, the following snippet adds the "U+000C" (form feed) character and disables the "U+00A0" (non-breaking space) character for markdown files:
+
+```
+"[markdown]": {
+  "gremlins.characters": {
+    // Add the form feed character for markdown files
+    "000c" : {
+      "zeroWidth": true,
+      "description": "FORM FEED (FF)",
+      "backgroundColor": "rgba(255,127,80,.5)",
+      "overviewRulerColor": "rgba(255,127,80,1)",
+    },
+    // Ignore the non-breaking space character for markdown files
+    "00a0": {
+      "level": "none"
+    }
+  }
+}
+```
 
 ## Hiding the gremlin icon in the gutter for a character
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ As an example, the following snippet adds the "U+000C" FORM FEED character:
   "000c" : {
     "zeroWidth": true,
     "description": "FORM FEED (FF)",
-    "backgroundColor": "rgba(255,127,80,.5)",
     "overviewRulerColor": "rgba(255,127,80,1)",
   }
 }
@@ -59,7 +58,6 @@ As an example, the following snippet adds the "U+000C" (form feed) character and
     "000c" : {
       "zeroWidth": true,
       "description": "FORM FEED (FF)",
-      "backgroundColor": "rgba(255,127,80,.5)",
       "overviewRulerColor": "rgba(255,127,80,1)",
     },
     // Ignore the non-breaking space character for markdown files

--- a/extension.js
+++ b/extension.js
@@ -25,6 +25,11 @@ let processedDocuments = {}
 
 let configuration = null
 
+const icons = {
+  light : null,
+  dark: null
+}
+
 let diagnosticCollection = null
 
 function configureDiagnosticsCollection(showDiagnostics) {
@@ -47,10 +52,19 @@ function disposeDecorationTypes() {
   decorationTypes = {}
 }
 
-function loadConfiguration(context) {
+/**
+ * 
+ * @param {vscode.ExtensionContext} context 
+ */
+function loadIcons(context) {
+  icons.light = context.asAbsolutePath('images/gremlins-light.svg')
+  icons.dark = context.asAbsolutePath('images/gremlins-dark.svg')
+}
+
+function loadConfiguration() {
   const gremlinsConfiguration = vscode.workspace.getConfiguration(GREMLINS)
 
-  const gremlins = gremlinsFromConfig(gremlinsConfiguration, context)
+  const gremlins = gremlinsFromConfig(gremlinsConfiguration)
 
   const showDiagnostics = vscode.workspace.getConfiguration(GREMLINS)
     .showInProblemPane
@@ -79,7 +93,7 @@ function loadConfiguration(context) {
   }
 }
 
-function gremlinsFromConfig(gremlinsConfiguration, context) {
+function gremlinsFromConfig(gremlinsConfiguration) {
   const gremlinsLevels = {
     [GREMLINS_LEVELS.INFO]: gremlinsConfiguration.color_info,
     [GREMLINS_LEVELS.WARNING]: gremlinsConfiguration.color_warning,
@@ -90,11 +104,11 @@ function gremlinsFromConfig(gremlinsConfiguration, context) {
   const hexCodePointsRangeRegex = /^([0-9a-f]+)(?:-([0-9a-f]+))?$/i
 
   const lightIcon = {
-    gutterIconPath: context.asAbsolutePath('images/gremlins-light.svg'),
+    gutterIconPath: icons.light,
     gutterIconSize: gutterIconSize,
   }
   const darkIcon = {
-    gutterIconPath: context.asAbsolutePath('images/gremlins-dark.svg'),
+    gutterIconPath: icons.dark,
     gutterIconSize: gutterIconSize,
   }
 
@@ -262,8 +276,14 @@ function drawDecorations(activeTextEditor, decorations) {
   }
 }
 
+/**
+ * 
+ * @param {vscode.ExtensionContext} context 
+ */
 function activate(context) {
-  configuration = loadConfiguration(context)
+  loadIcons(context)
+
+  configuration = loadConfiguration()
 
   const doCheckForGremlins = (editor) =>
     checkForGremlins(

--- a/extension.js
+++ b/extension.js
@@ -59,8 +59,12 @@ function loadIcons(context) {
   icons.dark = context.asAbsolutePath('images/gremlins-dark.svg')
 }
 
-function loadConfiguration() {
-  const gremlinsConfiguration = vscode.workspace.getConfiguration(GREMLINS)
+/**
+ * 
+ * @param {vscode.TextDocument} document 
+ */
+function loadConfiguration(document) {
+  const gremlinsConfiguration = vscode.workspace.getConfiguration(GREMLINS, document)
 
   const gremlins = gremlinsFromConfig(gremlinsConfiguration)
 
@@ -180,7 +184,7 @@ function checkForGremlins(
 
   const doc = activeTextEditor.document
 
-  let { gremlins, regexpWithAllChars, diagnosticCollection } = loadConfiguration()
+  let { gremlins, regexpWithAllChars, diagnosticCollection } = loadConfiguration(doc)
 
   const decorationOption = {}
   for (const char in gremlins) {
@@ -333,7 +337,7 @@ function deactivate() {
     diagnosticCollection.clear()
     diagnosticCollection.dispose()
   }
-
+  
   disposeDecorationTypes()
 
   eventListeners.forEach((listener) => listener.dispose())

--- a/package.json
+++ b/package.json
@@ -172,7 +172,8 @@
               },
               "level": {
                 "type": "string",
-                "description": "Severity level associated with this character",
+                "description": "Severity level associated with this character (default is error)",
+                "default": "error",
                 "enum": [
                   "none",
                   "info",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "gremlins.characters": {
           "type": "object",
           "description": "List of characters the extension should track",
+          "scope": "language-overridable",
           "default": {
             "2013": {
               "description": "en dash",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR makes certain configuration language-overridable.  This allows for gremlins to be defined differently for specific languages (e.g. allowing non-breaking spaces in Markdown, but flagging them elsewhere).

> Note: in order for this to work, we need to load configuration every time so we can make sure we have the appropriate configuration for the file being processed.  I did some benchmarking with Node's high-resolution timer, and it was taking in the area of 750ns to load the config, so the performance impact _should_ be minimal.

## Motivation and Context
Fixes #31 

## How Has This Been Tested?
I tried to unit test, but due to how we're mocking the loading of configuration, the mocks would make my test useless.  I tested via running the extension and seeing if I could change my settings in a language-specific block.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9260413/96253151-1906b580-0f81-11eb-8a3e-2f01c8670cfa.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
