### PR TITLE
Add configuration to disable ALL gremlins (useful for language-overrides)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can find all characters in [Unicode Table](https://unicode-table.com/en/).
 
 ## Language-specific gremlins characters
 
-You can override the characters for a specific language by configuring them in the `gremlins.characters` property of the language-specific settings key (e.g. `[markdown]` for Markdown files).
+You can override the characters for a specific language by configuring them in the `gremlins.characters` property of the language-specific settings key (e.g. `[markdown]` for Markdown files).  To completely disable gremlins for a specific language, you can use the `gremlins.disabled` property.
 
 > More information about language specific settings can be found in the [Language specific editor settings](https://code.visualstudio.com/docs/getstarted/settings#_language-specific-editor-settings) VSCode documentation page.
 
@@ -65,6 +65,10 @@ As an example, the following snippet adds the "U+000C" (form feed) character and
       "level": "none"
     }
   }
+},
+// Do not show any gremlins in plaintext files
+"[plaintext]": {
+  "gremlins.disabled": true
 }
 ```
 

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`configuration level setting \`gremlins.disabled\` to \`true\` prevents decoration from being displayed 1`] = `
+Array [
+  Array [
+    "document1",
+    Array [],
+  ],
+]
+`;
+
+exports[`configuration level setting \`gremlins.disabled\` to \`true\` prevents decoration from being displayed 2`] = `
+Array [
+  Array [
+    "document1",
+    Array [],
+  ],
+]
+`;
+
 exports[`configuration level setting level to none prevents decoration from being displayed 1`] = `
 Array [
   Array [

--- a/__snapshots__/extension.test.js.snap
+++ b/__snapshots__/extension.test.js.snap
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`configuration level setting \`gremlins.disabled\` to \`true\` prevents decoration from being displayed 1`] = `
+exports[`configuration gremlins.disabled when set to \`true\` prevents decoration from being displayed 1`] = `
+Array [
+  Array [
+    Object {
+      "dispose": [MockFunction],
+    },
+    Array [],
+  ],
+]
+`;
+
+exports[`configuration gremlins.disabled when set to \`true\` prevents decoration from being displayed 2`] = `Array []`;
+
+exports[`configuration gremlins.disabled when set to \`true\` prevents diagnostic from being displayed 1`] = `
 Array [
   Array [
     "document1",
@@ -9,16 +22,24 @@ Array [
 ]
 `;
 
-exports[`configuration level setting \`gremlins.disabled\` to \`true\` prevents decoration from being displayed 2`] = `
+exports[`configuration gremlins.disabled when set to \`true\` prevents diagnostic from being displayed 2`] = `
 Array [
   Array [
     "document1",
     Array [],
   ],
+  Array [
+    "document2",
+    Array [],
+  ],
+  Array [
+    "document3",
+    Array [],
+  ],
 ]
 `;
 
-exports[`configuration level setting level to none prevents decoration from being displayed 1`] = `
+exports[`configuration level when set to none prevents decoration from being displayed 1`] = `
 Array [
   Array [
     Object {
@@ -43,9 +64,9 @@ Array [
 ]
 `;
 
-exports[`configuration level setting level to none prevents decoration from being displayed 2`] = `Array []`;
+exports[`configuration level when set to none prevents decoration from being displayed 2`] = `Array []`;
 
-exports[`configuration level setting level to none prevents decoration from being displayed 3`] = `
+exports[`configuration level when set to none prevents diagnostic from being displayed 1`] = `
 Array [
   Array [
     "document1",
@@ -54,7 +75,7 @@ Array [
 ]
 `;
 
-exports[`configuration level setting level to none prevents decoration from being displayed 4`] = `
+exports[`configuration level when set to none prevents diagnostic from being displayed 2`] = `
 Array [
   Array [
     "document1",

--- a/extension.js
+++ b/extension.js
@@ -86,6 +86,10 @@ function loadConfiguration(document) {
 }
 
 function gremlinsFromConfig(gremlinsConfiguration) {
+  if (gremlinsConfiguration.disabled) {
+    return {}
+  }
+
   const gremlinsLevels = {
     [GREMLINS_LEVELS.INFO]: gremlinsConfiguration.color_info,
     [GREMLINS_LEVELS.WARNING]: gremlinsConfiguration.color_warning,
@@ -185,6 +189,10 @@ function checkForGremlins(
   const doc = activeTextEditor.document
 
   let { gremlins, regexpWithAllChars, diagnosticCollection } = loadConfiguration(doc)
+
+  if (Object.keys(gremlins).length === 0) {
+    return
+  }
 
   const decorationOption = {}
   for (const char in gremlins) {

--- a/extension.js
+++ b/extension.js
@@ -191,6 +191,10 @@ function checkForGremlins(
   let { gremlins, regexpWithAllChars, diagnosticCollection } = loadConfiguration(doc)
 
   if (Object.keys(gremlins).length === 0) {
+    // Clear any diagnostics from previous runs (after config change)
+    if (diagnosticCollection) {
+      diagnosticCollection.set(activeTextEditor.document.uri, [])
+    }
     return
   }
 

--- a/extension.js
+++ b/extension.js
@@ -191,7 +191,8 @@ function checkForGremlins(
   let { gremlins, regexpWithAllChars, diagnosticCollection } = loadConfiguration(doc)
 
   if (Object.keys(gremlins).length === 0) {
-    // Clear any diagnostics from previous runs (after config change)
+    // If there are now no configured gremlins, clear any diagnostics from
+    // previous runs and short-curcuit.
     if (diagnosticCollection) {
       diagnosticCollection.set(activeTextEditor.document.uri, [])
     }

--- a/extension.test.js
+++ b/extension.test.js
@@ -479,5 +479,21 @@ describe('configuration', () => {
       // Diagnostic is no longer created
       expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
     })
+    
+    it('setting `gremlins.disabled` to `true` prevents decoration from being displayed', () => {
+      // Default is to create diagnostic
+      mockDocument.text = 'zero width space \u200b'
+      activate(context)
+      expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+
+      // When overriding level to 'none'
+      mockSetDecorations.mockClear()
+      mockConfiguration.disabled = true
+      const configChangeHandler = mockVscode.workspace.onDidChangeConfiguration.mock.calls[0][0]
+      configChangeHandler({ affectsConfiguration: () => true})
+
+      // Diagnostic is no longer created
+      expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
+    })
   })
 })

--- a/extension.test.js
+++ b/extension.test.js
@@ -448,7 +448,7 @@ describe('deactivate', () => {
 
 describe('configuration', () => {
   describe('level', () => {
-    it('setting level to none prevents decoration from being displayed', () => {
+    it('when set to none prevents decoration from being displayed', () => {
       // Default is to display decoration
       mockDocument.text = 'zero width space \u200b'
       activate(context)
@@ -463,8 +463,8 @@ describe('configuration', () => {
       // Decoration is no longer displayed
       expect(mockSetDecorations.mock.calls).toMatchSnapshot()
     })
-    
-    it('setting level to none prevents decoration from being displayed', () => {
+
+    it('when set to none prevents diagnostic from being displayed', () => {
       // Default is to create diagnostic
       mockDocument.text = 'zero width space \u200b'
       activate(context)
@@ -479,8 +479,26 @@ describe('configuration', () => {
       // Diagnostic is no longer created
       expect(mockSetDiagnostics.mock.calls).toMatchSnapshot()
     })
+  })
+
+  describe('gremlins.disabled', () => {
+    it('when set to `true` prevents decoration from being displayed', () => {
+      // Default is to display decoration
+      mockDocument.text = 'zero width space \u200b'
+      activate(context)
+      expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+
+      // When overriding level to 'none'
+      mockSetDecorations.mockClear()
+      mockConfiguration.disabled = true
+      const configChangeHandler = mockVscode.workspace.onDidChangeConfiguration.mock.calls[0][0]
+      configChangeHandler({ affectsConfiguration: () => true})
+
+      // Decoration is no longer displayed
+      expect(mockSetDecorations.mock.calls).toMatchSnapshot()
+    })
     
-    it('setting `gremlins.disabled` to `true` prevents decoration from being displayed', () => {
+    it('when set to `true` prevents diagnostic from being displayed', () => {
       // Default is to create diagnostic
       mockDocument.text = 'zero width space \u200b'
       activate(context)

--- a/package.json
+++ b/package.json
@@ -209,6 +209,12 @@
           "type": "boolean",
           "default": false,
           "description": "Show gremlins in the problem pane"
+        },
+        "gremlins.disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable processing of all gremlins characters (used for disabling for files of a specific languages)",
+          "scope": "language-overridable"
         }
       }
     }


### PR DESCRIPTION
## Description
This PR adds a `gremlins.disabled` configuration that allows all processing to be disabled.  This setting is intended to be used with language-specific configurations so that gremlins can be completely ignored for files of a specific type.

## Motivation and Context
This builds upon the language-specific configuration and allows ALL gremlins to be disabled for a given language without needing to manually override each of them individually.

## How Has This Been Tested?
This has been tested using both manual and unit tests.  I have tested turning the setting on to confirm that no gremlins are processed.  Additionally, I have tested turning it on for a specific language, as well as turning it on globally, and then off for a specific language.  In all cases, the expected behavior has been observed.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
