### PR TITLE
docs: 📘  improve readme with example on range based rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ As an example, the following snippet adds the "U+000C" (form feed) character and
   }
 }
 ```
+## Specifying a Range of Invalid Characters
+
+You can give a range to flag multiple characters with a single rule.
+
+For example, if using macOS and the option key is set to a modifier, it's easy to accidentally include a [Latin-1 Supplemental Character](https://unicode-table.com/en/blocks/latin-1-supplement/) that can be difficult to notice in your code.
+
+To catch the entire range, the Latin-1-Supplement link provided shows a unicode range of: `0080—00FF`
+
+Configure a rule like this:
+
+```jsonc
+"gremlins.characters": {
+    "0080-00FF": {
+        "level": "error",
+        "zeroWidth": false,
+        "description": "Latin-1 Supplement character identified",
+        "overviewRulerColor": "rgba(255,127,80,1)",
+    },
+}
+```
+
 
 ## Hiding the gremlin icon in the gutter for a character
 
@@ -82,6 +103,15 @@ For example, this removes the gremlin icon in the gutter for non breakable space
     "hideGutterIcon": true
   }
 }
+```
+
+To test this out, copy some of the [characters](https://unicode-table.com/en/blocks/latin-1-supplement/) or try the sample below.
+If you have the problems pane set to flag as errors, this should show up immediately with each character being identified as a problem.
+
+```text
+»
+×
+Ö
 ```
 
 ## Displaying gremlins in the Problems pane

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Configure a rule like this:
 }
 ```
 
+To test this out, copy some of the [characters](https://unicode-table.com/en/blocks/latin-1-supplement/) or try the sample below.
+If you have the problems pane set to flag as errors, this should show up immediately with each character being identified as a problem.
+
+```text
+»
+×
+Ö
+```
 
 ## Hiding the gremlin icon in the gutter for a character
 
@@ -103,15 +111,6 @@ For example, this removes the gremlin icon in the gutter for non breakable space
     "hideGutterIcon": true
   }
 }
-```
-
-To test this out, copy some of the [characters](https://unicode-table.com/en/blocks/latin-1-supplement/) or try the sample below.
-If you have the problems pane set to flag as errors, this should show up immediately with each character being identified as a problem.
-
-```text
-»
-×
-Ö
 ```
 
 ## Displaying gremlins in the Problems pane


### PR DESCRIPTION
- include link to unicode docs with range and character definitions
- provide example characters to paste for quick test
- example config for Latin-1-Supplemental characters

fixes #184
