### PR TITLE
Add 2 risky zero width charcters

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,16 @@
               "description": "paragraph separator",
               "level": "error"
             },
+            "2066": {
+              "zeroWidth": true,
+              "description": "Left to right",
+              "level": "error"
+            },
+            "2069": {
+              "zeroWidth": true,
+              "description": "Pop directional",
+              "level": "error"
+            },
             "0003": {
               "description": "end of text",
               "level": "warning"


### PR DESCRIPTION
When using RTL version of Whatsapp web and copying a number, WhatsApp web adding those characters to the number

![image](https://user-images.githubusercontent.com/3584317/133921303-5e6679be-0f58-4ee9-ad57-688135bd3e65.png)
