### PR TITLE
Add null character to default gremlins

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
           "description": "List of characters the extension should track",
           "scope": "language-overridable",
           "default": {
+            "0000": {
+              "zeroWidth": true,
+              "description": "null",
+              "level": "error"
+            },
             "2013": {
               "description": "en dash",
               "level": "warning"


### PR DESCRIPTION

## Description
Add `null` character to defaults

## Motivation and Context
Closes issue https://github.com/nhoizey/vscode-gremlins/issues/109
Null chars break text files in bash and other languages. Every time I reinstall `vscode-gremlins` I have to re-add this rule.

## How Has This Been Tested?
Open file, see null gremlin, smile :)

## Screenshots (if appropriate):
![image](https://github.com/nhoizey/vscode-gremlins/assets/1692132/bb25513e-3d59-499a-8bb2-c60dccec4f2d)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
